### PR TITLE
Add pitch depending on age for emotes

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.Emote.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Emote.cs
@@ -155,7 +155,7 @@ public partial class ChatSystem
         // Imperial Medieval AgePitch Begin
         if (TryComp<Shared.Humanoid.HumanoidAppearanceComponent>(uid, out var comp))
             param.Pitch += Math.Clamp((50f - comp.Age) * 0.05f, -0.5f, 5f);
-        Log.Debug(param.Pitch.ToString());
+
         // Imperial Medieval AgePitch End
         _audio.PlayPvs(sound, uid, param);
         return true;

--- a/Content.Server/Chat/Systems/ChatSystem.Emote.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.Emote.cs
@@ -152,6 +152,11 @@ public partial class ChatSystem
 
         // if general params for all sounds set - use them
         var param = proto.GeneralParams ?? sound.Params;
+        // Imperial Medieval AgePitch Begin
+        if (TryComp<Shared.Humanoid.HumanoidAppearanceComponent>(uid, out var comp))
+            param.Pitch += Math.Clamp((50f - comp.Age) * 0.05f, -0.5f, 5f);
+        Log.Debug(param.Pitch.ToString());
+        // Imperial Medieval AgePitch End
         _audio.PlayPvs(sound, uid, param);
         return true;
     }


### PR DESCRIPTION
Добавляет питч для эмоутов по формуле 1 + Math.Clamp((50 - возраст) * 0.05, -0.5, 5)
Формула скорее всего будет изменяться