### PR TITLE
Фикс испарения жидкостей

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/hydroponics.yml
+++ b/Resources/Prototypes/Imperial/Medieval/hydroponics.yml
@@ -256,6 +256,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -294,6 +296,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -332,6 +336,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -370,6 +376,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -408,6 +416,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -444,6 +454,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -480,6 +492,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3

--- a/Resources/Prototypes/Imperial/Medieval/medieval.yml
+++ b/Resources/Prototypes/Imperial/Medieval/medieval.yml
@@ -2675,6 +2675,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -2761,6 +2763,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -2794,6 +2798,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -2827,6 +2833,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -2860,6 +2868,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -2910,6 +2920,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -2941,6 +2953,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3
@@ -3061,6 +3075,8 @@
   group: Elements
   desc: .
   physicalDesc: reagent-physical-desc-dark-brown
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#BC8A00"
   boilingPoint: 184.3

--- a/Resources/Prototypes/Imperial/Medieval/medievalchem.yml
+++ b/Resources/Prototypes/Imperial/Medieval/medievalchem.yml
@@ -141,6 +141,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#FFC8C8"
 
@@ -168,6 +170,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#215263"
   abstract: true
@@ -187,6 +191,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#0041a8"
   abstract: true
@@ -204,6 +210,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#a1000b"
   boilingPoint: 78.2 # This isn't a real chemical...
@@ -250,6 +258,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#00ff5f"
   boilingPoint: 340282300000000000000000000000000000000 # Ethidium bromide, which doesn't boil.
@@ -281,6 +291,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -304,6 +316,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -318,6 +332,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -333,6 +349,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -348,6 +366,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -365,6 +385,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#FFC8C8"
   abstract: true
@@ -392,6 +414,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#FFC8C8"
   abstract: true
@@ -420,6 +444,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -436,6 +462,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true 
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -452,6 +480,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -468,6 +498,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true 
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -486,6 +518,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -525,6 +559,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true 
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -541,6 +577,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -563,6 +601,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -587,6 +627,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -638,6 +680,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#215263"
   abstract: true
@@ -657,6 +701,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -670,6 +716,8 @@
 
 - type: reagent
   id: medievaladvancedhealpiercing
+  evaporationSpeed: 0.3
+  absorbent: true 
   name: ""
   desc: ""
   physicalDesc: ""
@@ -686,6 +734,8 @@
 
 - type: reagent
   id: medievaladvancedhealblunt
+  evaporationSpeed: 0.3
+  absorbent: true
   name: ""
   desc: ""
   physicalDesc: ""
@@ -705,6 +755,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#215263"
   abstract: true
@@ -723,6 +775,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#a1000b"
   boilingPoint: 78.2 # This isn't a real chemical...
@@ -771,6 +825,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -786,6 +842,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -801,6 +859,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -818,6 +878,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -840,6 +902,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -858,6 +922,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#9A040E"
   abstract: true
@@ -908,6 +974,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -932,6 +1000,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -946,6 +1016,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#FFC8C8"
   reactiveEffects:
@@ -1009,6 +1081,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -1041,6 +1115,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true
@@ -1063,6 +1139,8 @@
   name: ""
   desc: ""
   physicalDesc: ""
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: ""
   color: "#63806e"
   abstract: true

--- a/Resources/Prototypes/Imperial/Other/MedicalImproves/Reagents/imperialmedicine.yml
+++ b/Resources/Prototypes/Imperial/Other/MedicalImproves/Reagents/imperialmedicine.yml
@@ -91,6 +91,8 @@
   group: Medicine
   desc: reagent-desc-thrivenin
   physicalDesc: reagent-physical-desc-translucent
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: medicine
   pricePerUnit: 10
   color: "#ffaa00"
@@ -124,6 +126,8 @@
   pricePerUnit: 1.1 #imperial
   desc: reagent-desc-spaceacillin
   physicalDesc: reagent-physical-desc-opaque
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: medicine
   color: "#9942f5"
   metabolisms:

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -29,8 +29,8 @@
   name: reagent-name-ale
   parent: BaseAlcohol
   desc: reagent-desc-ale
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-bubbly
   flavor: ale
   color: "#663100"
@@ -48,8 +48,8 @@
   name: reagent-name-beer
   parent: BaseAlcohol
   desc: reagent-desc-beer
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-bubbly
   flavor: beer
   color: "#e3e77b"
@@ -136,9 +136,9 @@
   id: Ethanol
   name: reagent-name-ethanol
   parent: BaseAlcohol
-  desc: reagent-desc-
-  evaporationSpeed: 0.3
-  absorbent: true
+  desc: reagent-desc-ethanol
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: alcohol
   color: "#b05b3c"
@@ -311,8 +311,8 @@
   parent: BaseAlcohol
   desc: reagent-desc-rum
   physicalDesc: reagent-physical-desc-strong-smelling
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: rum
   color: "#f09f42"
   recognizable: true
@@ -397,8 +397,8 @@
   name: reagent-name-vodka
   parent: BaseAlcohol
   desc: reagent-desc-vodka
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: vodka
   color: "#d1d1d155"
@@ -447,8 +447,8 @@
   name: reagent-name-wine
   parent: BaseAlcohol
   desc: reagent-desc-wine
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-translucent
   flavor: shittywine
   color: "#7E4043"
@@ -917,8 +917,8 @@
   name: reagent-name-demons-blood
   parent: BaseAlcohol
   desc: reagent-desc-demons-blood
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-ferrous
   flavor: demonsblood
   color: "#a70000"
@@ -1421,8 +1421,8 @@
   name: reagent-name-mead
   parent: BaseAlcohol
   desc: reagent-desc-mead
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: mead
   color: "#664300"
@@ -1470,8 +1470,8 @@
   name: reagent-name-moonshine
   parent: BaseAlcohol
   desc: reagent-desc-moonshine
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-pungent
   flavor: moonshine
   color: "#d1d7d155"
@@ -1570,8 +1570,8 @@
   name: reagent-name-red-mead
   parent: BaseAlcohol
   desc: reagent-desc-red-mead
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-ferrous
   flavor: redmead
   color: "#bc5550"

--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -29,6 +29,8 @@
   name: reagent-name-ale
   parent: BaseAlcohol
   desc: reagent-desc-ale
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-bubbly
   flavor: ale
   color: "#663100"
@@ -46,6 +48,8 @@
   name: reagent-name-beer
   parent: BaseAlcohol
   desc: reagent-desc-beer
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-bubbly
   flavor: beer
   color: "#e3e77b"
@@ -132,7 +136,9 @@
   id: Ethanol
   name: reagent-name-ethanol
   parent: BaseAlcohol
-  desc: reagent-desc-ethanol
+  desc: reagent-desc-
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: alcohol
   color: "#b05b3c"
@@ -305,6 +311,8 @@
   parent: BaseAlcohol
   desc: reagent-desc-rum
   physicalDesc: reagent-physical-desc-strong-smelling
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: rum
   color: "#f09f42"
   recognizable: true
@@ -389,6 +397,8 @@
   name: reagent-name-vodka
   parent: BaseAlcohol
   desc: reagent-desc-vodka
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: vodka
   color: "#d1d1d155"
@@ -437,6 +447,8 @@
   name: reagent-name-wine
   parent: BaseAlcohol
   desc: reagent-desc-wine
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-translucent
   flavor: shittywine
   color: "#7E4043"
@@ -905,6 +917,8 @@
   name: reagent-name-demons-blood
   parent: BaseAlcohol
   desc: reagent-desc-demons-blood
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-ferrous
   flavor: demonsblood
   color: "#a70000"
@@ -1407,6 +1421,8 @@
   name: reagent-name-mead
   parent: BaseAlcohol
   desc: reagent-desc-mead
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: mead
   color: "#664300"
@@ -1454,6 +1470,8 @@
   name: reagent-name-moonshine
   parent: BaseAlcohol
   desc: reagent-desc-moonshine
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-pungent
   flavor: moonshine
   color: "#d1d7d155"
@@ -1552,6 +1570,8 @@
   name: reagent-name-red-mead
   parent: BaseAlcohol
   desc: reagent-desc-red-mead
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-ferrous
   flavor: redmead
   color: "#bc5550"

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -250,6 +250,8 @@
   name: reagent-name-milk
   group: Drinks
   desc: reagent-desc-milk
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-opaque
   flavor: milk
   color: "#DFDFDF"

--- a/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/drinks.yml
@@ -250,8 +250,8 @@
   name: reagent-name-milk
   group: Drinks
   desc: reagent-desc-milk
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-opaque
   flavor: milk
   color: "#DFDFDF"

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -4,6 +4,8 @@
   name: reagent-name-nutriment
   group: Foods
   desc: reagent-desc-nutriment
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-opaque
   flavor: nutriment
   color: "#24591F"
@@ -23,6 +25,8 @@
   name: reagent-name-vitamin
   group: Foods
   desc: reagent-desc-vitamin
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-chalky
   flavor: vitamin
   color: "#D3D3D3"
@@ -52,6 +56,8 @@
   name: reagent-name-protein
   group: Foods
   desc: reagent-desc-protein
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-clumpy
   flavor: protein
   color: "#FFFFE5"

--- a/Resources/Prototypes/Reagents/Consumable/Food/food.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Food/food.yml
@@ -4,8 +4,8 @@
   name: reagent-name-nutriment
   group: Foods
   desc: reagent-desc-nutriment
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-opaque
   flavor: nutriment
   color: "#24591F"
@@ -25,8 +25,8 @@
   name: reagent-name-vitamin
   group: Foods
   desc: reagent-desc-vitamin
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-chalky
   flavor: vitamin
   color: "#D3D3D3"
@@ -56,8 +56,8 @@
   name: reagent-name-protein
   group: Foods
   desc: reagent-desc-protein
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-clumpy
   flavor: protein
   color: "#FFFFE5"

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -3,8 +3,8 @@
   name: reagent-name-blood
   group: Biological
   desc: reagent-desc-blood
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: metallic
   color: "#800000"
   metamorphicSprite:
@@ -86,8 +86,8 @@
   name: reagent-name-sap
   group: Biological
   desc: reagent-desc-sap
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: sweet
   color: "#cd7314"
   recognizable: true
@@ -207,8 +207,8 @@
   name: reagent-name-vomit
   group: Biological
   desc: reagent-desc-vomit
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: terrible
   color: "#87ab08"
   physicalDesc: reagent-physical-desc-pungent

--- a/Resources/Prototypes/Reagents/biological.yml
+++ b/Resources/Prototypes/Reagents/biological.yml
@@ -3,6 +3,8 @@
   name: reagent-name-blood
   group: Biological
   desc: reagent-desc-blood
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: metallic
   color: "#800000"
   metamorphicSprite:
@@ -84,6 +86,8 @@
   name: reagent-name-sap
   group: Biological
   desc: reagent-desc-sap
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: sweet
   color: "#cd7314"
   recognizable: true
@@ -203,6 +207,8 @@
   name: reagent-name-vomit
   group: Biological
   desc: reagent-desc-vomit
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: terrible
   color: "#87ab08"
   physicalDesc: reagent-physical-desc-pungent

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -22,8 +22,8 @@
   name: reagent-name-left4-zed
   group: Botanical
   desc: reagent-desc-left4-zed
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: bitter
   color: "#5b406c"
   physicalDesc: reagent-physical-desc-heterogeneous
@@ -79,8 +79,8 @@
   name: reagent-name-plant-b-gone
   group: Botanical
   desc: reagent-desc-plant-b-gone
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: bitter
   color: "#49002E"
   physicalDesc: reagent-physical-desc-bubbling
@@ -112,8 +112,8 @@
   name: reagent-name-robust-harvest
   group: Botanical
   desc: reagent-desc-robust-harvest
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: bitter
   color: "#3e901c"
   physicalDesc: reagent-physical-desc-robust
@@ -207,8 +207,8 @@
   group: Botanical
   desc: reagent-desc-ammonia
   physicalDesc: reagent-physical-desc-pungent
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: bitter
   color: "#77b58e"
   boilingPoint: -33.0
@@ -287,8 +287,8 @@
   name: reagent-name-diethylamine
   group: Botanical
   desc: reagent-desc-diethylamine
-  evaporationSpeed: 0.3
-  absorbent: true 
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true  # imperial medieval
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bitter
   color: "#a1000b"

--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -22,6 +22,8 @@
   name: reagent-name-left4-zed
   group: Botanical
   desc: reagent-desc-left4-zed
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#5b406c"
   physicalDesc: reagent-physical-desc-heterogeneous
@@ -77,6 +79,8 @@
   name: reagent-name-plant-b-gone
   group: Botanical
   desc: reagent-desc-plant-b-gone
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#49002E"
   physicalDesc: reagent-physical-desc-bubbling
@@ -108,6 +112,8 @@
   name: reagent-name-robust-harvest
   group: Botanical
   desc: reagent-desc-robust-harvest
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#3e901c"
   physicalDesc: reagent-physical-desc-robust
@@ -201,6 +207,8 @@
   group: Botanical
   desc: reagent-desc-ammonia
   physicalDesc: reagent-physical-desc-pungent
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#77b58e"
   boilingPoint: -33.0
@@ -279,6 +287,8 @@
   name: reagent-name-diethylamine
   group: Botanical
   desc: reagent-desc-diethylamine
+  evaporationSpeed: 0.3
+  absorbent: true 
   physicalDesc: reagent-physical-desc-strong-smelling
   flavor: bitter
   color: "#a1000b"

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -144,8 +144,8 @@
   group: Elements
   desc: reagent-desc-iron
   physicalDesc: reagent-physical-desc-metallic
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: metallic
   color: "#434b4d"
   boilingPoint: 2862.0

--- a/Resources/Prototypes/Reagents/elements.yml
+++ b/Resources/Prototypes/Reagents/elements.yml
@@ -144,6 +144,8 @@
   group: Elements
   desc: reagent-desc-iron
   physicalDesc: reagent-physical-desc-metallic
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: metallic
   color: "#434b4d"
   boilingPoint: 2862.0

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -120,8 +120,8 @@
   group: Medicine
   desc: reagent-desc-arithrazine
   physicalDesc: reagent-physical-desc-cloudy
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: medicine
   color: "#bd5902"
   metabolisms:
@@ -280,8 +280,8 @@
   group: Medicine
   desc: reagent-desc-dexalin-plus
   physicalDesc: reagent-physical-desc-cloudy
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: medicine
   color: "#4da0bd"
   metabolisms:
@@ -568,8 +568,8 @@
   group: Medicine
   desc: reagent-desc-phalanximine
   physicalDesc: reagent-physical-desc-acrid
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: medicine
   color: "#c8ff75"
   plantMetabolism:
@@ -768,8 +768,8 @@
   group: Medicine
   desc: reagent-desc-tranexamic-acid
   physicalDesc: reagent-physical-desc-
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: medicine
   color: "#ba7d7d"
   metabolisms:
@@ -832,8 +832,8 @@
   name: reagent-name-omnizine
   group: Medicine
   desc: reagent-desc-omnizine
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-soothing
   flavor: medicine
   color: "#fcf7f9"

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -120,6 +120,8 @@
   group: Medicine
   desc: reagent-desc-arithrazine
   physicalDesc: reagent-physical-desc-cloudy
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: medicine
   color: "#bd5902"
   metabolisms:
@@ -278,6 +280,8 @@
   group: Medicine
   desc: reagent-desc-dexalin-plus
   physicalDesc: reagent-physical-desc-cloudy
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: medicine
   color: "#4da0bd"
   metabolisms:
@@ -564,6 +568,8 @@
   group: Medicine
   desc: reagent-desc-phalanximine
   physicalDesc: reagent-physical-desc-acrid
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: medicine
   color: "#c8ff75"
   plantMetabolism:
@@ -761,7 +767,9 @@
   name: reagent-name-tranexamic-acid
   group: Medicine
   desc: reagent-desc-tranexamic-acid
-  physicalDesc: reagent-physical-desc-viscous
+  physicalDesc: reagent-physical-desc-
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: medicine
   color: "#ba7d7d"
   metabolisms:
@@ -824,6 +832,8 @@
   name: reagent-name-omnizine
   group: Medicine
   desc: reagent-desc-omnizine
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-soothing
   flavor: medicine
   color: "#fcf7f9"

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -767,7 +767,7 @@
   name: reagent-name-tranexamic-acid
   group: Medicine
   desc: reagent-desc-tranexamic-acid
-  physicalDesc: reagent-physical-desc-
+  physicalDesc: reagent-physical-desc-viscous
   evaporationSpeed: 0.3 # imperial medieval
   absorbent: true # imperial medieval
   flavor: medicine

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -113,7 +113,7 @@
   name: reagent-name-stimulants
   group: Narcotics
   desc: reagent-desc-stimulants
-  physicalDesc: reagent-physical-desc-stimulants
+  physicalDesc: reagent-physical-desc-energizing
   evaporationSpeed: 0.3 # imperial medieval
   absorbent: true # imperial medieval
   flavor: sharp

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -113,7 +113,9 @@
   name: reagent-name-stimulants
   group: Narcotics
   desc: reagent-desc-stimulants
-  physicalDesc: reagent-physical-desc-energizing
+  physicalDesc: reagent-physical-desc-
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: sharp
   color: "#9A040E"
   boilingPoint: 212.0
@@ -224,6 +226,8 @@
   group: Narcotics
   desc: reagent-desc-impedrezene
   physicalDesc: reagent-physical-desc-acrid
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#215263"
   metabolisms:
@@ -253,6 +257,8 @@
   group: Narcotics
   desc: reagent-desc-space-drugs
   physicalDesc: reagent-physical-desc-syrupy
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#63806e"
   metabolisms:
@@ -290,6 +296,8 @@
   group: Narcotics
   desc: reagent-desc-nocturine
   physicalDesc: reagent-physical-desc-powdery
+  evaporationSpeed: 0.3
+  absorbent: true
   color: "#128e80"
   boilingPoint: 444.0
   meltingPoint: 128.0
@@ -312,6 +320,8 @@
   group: Narcotics
   desc: reagent-desc-mute-toxin
   physicalDesc: reagent-physical-desc-syrupy
+  evaporationSpeed: 0.3
+  absorbent: true
   color: "#000000"
   boilingPoint: 255.0
   meltingPoint: 36.0

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -114,8 +114,8 @@
   group: Narcotics
   desc: reagent-desc-stimulants
   physicalDesc: reagent-physical-desc-
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: sharp
   color: "#9A040E"
   boilingPoint: 212.0
@@ -226,8 +226,8 @@
   group: Narcotics
   desc: reagent-desc-impedrezene
   physicalDesc: reagent-physical-desc-acrid
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: bitter
   color: "#215263"
   metabolisms:
@@ -257,8 +257,8 @@
   group: Narcotics
   desc: reagent-desc-space-drugs
   physicalDesc: reagent-physical-desc-syrupy
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: bitter
   color: "#63806e"
   metabolisms:
@@ -296,8 +296,8 @@
   group: Narcotics
   desc: reagent-desc-nocturine
   physicalDesc: reagent-physical-desc-powdery
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   color: "#128e80"
   boilingPoint: 444.0
   meltingPoint: 128.0
@@ -320,8 +320,8 @@
   group: Narcotics
   desc: reagent-desc-mute-toxin
   physicalDesc: reagent-physical-desc-syrupy
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   color: "#000000"
   boilingPoint: 255.0
   meltingPoint: 36.0

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -113,7 +113,7 @@
   name: reagent-name-stimulants
   group: Narcotics
   desc: reagent-desc-stimulants
-  physicalDesc: reagent-physical-desc-
+  physicalDesc: reagent-physical-desc-stimulants
   evaporationSpeed: 0.3 # imperial medieval
   absorbent: true # imperial medieval
   flavor: sharp

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -99,6 +99,8 @@
   parent: BasePyrotechnic
   desc: reagent-desc-chlorine-trifluoride
   physicalDesc: reagent-physical-desc-blazing
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#FFC8C8"
   tileReactions:

--- a/Resources/Prototypes/Reagents/pyrotechnic.yml
+++ b/Resources/Prototypes/Reagents/pyrotechnic.yml
@@ -99,8 +99,8 @@
   parent: BasePyrotechnic
   desc: reagent-desc-chlorine-trifluoride
   physicalDesc: reagent-physical-desc-blazing
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: bitter
   color: "#FFC8C8"
   tileReactions:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -278,8 +278,8 @@
   group: Toxins
   desc: reagent-desc-unstable-mutagen
   physicalDesc: reagent-physical-desc-glowing
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   flavor: bitter
   color: "#00ff5f"
   boilingPoint: 340282300000000000000000000000000000000 # Ethidium bromide, which doesn't boil.
@@ -420,8 +420,8 @@
   name: reagent-name-amatoxin
   group: Toxins
   desc: reagent-desc-amatoxin
-  evaporationSpeed: 0.3
-  absorbent: true
+  evaporationSpeed: 0.3 # imperial medieval
+  absorbent: true # imperial medieval
   physicalDesc: reagent-physical-desc-nondescript
   color: "#D6CE7B"
   metabolisms:

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -278,6 +278,8 @@
   group: Toxins
   desc: reagent-desc-unstable-mutagen
   physicalDesc: reagent-physical-desc-glowing
+  evaporationSpeed: 0.3
+  absorbent: true
   flavor: bitter
   color: "#00ff5f"
   boilingPoint: 340282300000000000000000000000000000000 # Ethidium bromide, which doesn't boil.
@@ -418,6 +420,8 @@
   name: reagent-name-amatoxin
   group: Toxins
   desc: reagent-desc-amatoxin
+  evaporationSpeed: 0.3
+  absorbent: true
   physicalDesc: reagent-physical-desc-nondescript
   color: "#D6CE7B"
   metabolisms:


### PR DESCRIPTION
## Добавление возможности испарение к жидкостям:

```
"Blood",
"DemonsBlood",
"Sap",
"Ethanol",
"Protein",
"Vomit",
"Amatoxin",
"Vitamin",
"Nutriment",
"Milk",
"Wine",
"Vodka",
"Mead",
"RedMead",
"Beer",
"Rum",
"Moonshine",
"Ale",
"Arithrazine",
"DexalinPlus",
"Impedrezene",
"Spaceacillin",
"UnstableMutagen",
"SpaceDrugs",
"Nocturine",
"Omnizine",
"Stimulants",
"MuteToxin",
"Thrivenin",
"Phalanximine",
"ChlorineTrifluoride",
"Iron",
"TranexamicAcid",
"RobustHarvest",
"medievalexplosion",
"medievalhealburn",
"medievalhealbloodandoxygen",
"medievalacid",
"medievalradiation",
"medievaldrughealmech",
"medievalvomit",
"Ammonia",
"PlantBGone",
"Left4Zed",
"Diethylamine",
"medievalslow",
"medievalfast",
"medievalstamina",
"medievalsmoke",
"Antihol",
"medievalcryoexplosion",
"medievalhealslash",
"medievalhealpiercing",
"medievalhealblunt",
"medievalmute",
"medievalblind",
"medievaljitter",
"medievalsleep",
"medievalignite",
"medievalhealandstopblood",
"medievaladvancedhealeverything",
"medievaladvancedhealslash",
"medievaladvancedhealpiercing",
"medievaladvancedhealblunt",
"medievaladvancedhealburn",
"medievaladvancedacidradiation",
"medievaladvancedfast",
"medievaladvancedslow",
"medievaladvancedpacifism",
"medievaladvancedteleport",
"medievaladvancedhealandstopblood",
"medievaladvancedstimulant",
"medievaladvancedignite",
"medievaladvancednocturnblood",
"medievaladvancedsmokeandexplosion"
```
