### PR TITLE
Лежанка мирмексов, свитки в луте, компонент для магов.

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/jobs.yml
+++ b/Resources/Prototypes/Imperial/Medieval/jobs.yml
@@ -1796,6 +1796,7 @@
       regen: 0.4
     - type: MedievalJobSpawn
       spawnType: Default
+    - type: MagicRuneKnowledge
     - type: GiveItemObjective
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective400800
@@ -2404,6 +2405,7 @@
     #  faction: Legion
     - type: MedievalJobSpawn
       spawnType: Legion
+    - type: MagicRuneKnowledge
     - type: GiveItemObjective
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective400800
@@ -2973,6 +2975,7 @@
     #  faction: Insurgency
     - type: MedievalJobSpawn
       spawnType: Insurgency
+    - type: MagicRuneKnowledge
     - type: GiveItemObjective
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective400800

--- a/Resources/Prototypes/Imperial/Medieval/loot.yml
+++ b/Resources/Prototypes/Imperial/Medieval/loot.yml
@@ -330,6 +330,8 @@
         prob: 0.1
       - id: MedievalRepairStone
         prob: 0.05
+      - id: MedievalScrollBarrier
+        prob: 0.05
       - id: MedievalDrugChemistryBottle
         prob: 0.04
       - id: MedievalBrutepack
@@ -1198,6 +1200,8 @@
         prob: 0.07
       - id: MedievalKnut
         prob: 0.09
+      - id: MedievalScrollBarrier
+        prob: 0.1
       - id: MedaljonDark
         prob: 0.015
       - id: MedaljonExpl
@@ -1410,6 +1414,8 @@
         prob: 0.04
       - id: MedievalBanjoInstrument
         prob: 0.1
+      - id: MedievalScrollBarrier
+        prob: 0.2
       - id: MedievalShovel
         prob: 0.03
       #- id: MedievalWrench

--- a/Resources/Prototypes/Imperial/Medieval/myrmestructures.yml
+++ b/Resources/Prototypes/Imperial/Medieval/myrmestructures.yml
@@ -378,13 +378,13 @@
   - type: HealOnBuckle
     damage:
       groups:
-        Brute: -0.5
-        Burn: -0.5
-        Airloss: -1.6
+        Brute: -1.5
+        Burn: -1.5
+        Airloss: -4.8
       types:
-        Poison: -0.2
-        Caustic: -0.1
-        Radiation: -0.2
+        Poison: -0.6
+        Caustic: -0.3
+        Radiation: -0.6
   - type: Construction
     graph: MMyrmexBed
     node: medievalMyrmexBed


### PR DESCRIPTION
## О ПР`е
<!-- Что вы поменяли? -->
Хил на лежанке мирмексов увеличен в 3 раза.
Компоненты добавлены магам легиона и мятежа и вольному магу.
Свиток для барьера добавлен в лут сундуков.
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->
