### PR TITLE
Фикс Action'ов

### DIFF
--- a/Content.Shared/Imperial/Medieval/Surrender/CanSurrenderComponent.cs
+++ b/Content.Shared/Imperial/Medieval/Surrender/CanSurrenderComponent.cs
@@ -2,10 +2,11 @@ using Content.Shared.Actions;
 using Robust.Shared.Audio;
 using Robust.Shared.Player;
 using Robust.Shared.Serialization;
+using Robust.Shared.GameStates;
 
 namespace Content.Shared.Imperial.Medieval.Surrender
 {
-    [RegisterComponent]
+    [RegisterComponent, NetworkedComponent]
     public sealed partial class CanSurrenderComponent : Component
     {
         public bool SurrenderActive = false;

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Darkness/CultDagger/actions.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Darkness/CultDagger/actions.yml
@@ -13,7 +13,7 @@
         bonusEssences:
           MagicMedievalDarkness: 1
   - type: MedievalInstantSpell
-  - type: InstantAction
+  - type: Action
     useDelay: 4
     itemIconStyle: BigAction
     sound: !type:SoundPathSpecifier
@@ -21,6 +21,7 @@
     icon:
       sprite: Imperial/Medieval/Gun/Charmer/dagger_cult_magic.rsi
       state: 1
+  - type: InstantAction
     event: !type:MedievalSpawnInHandSpellEvent
       spawnedEntityPrototype: MedievalMagicDaggerCult
       spellCastDoAfter:

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Darkness/CursedFetter/actions.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Darkness/CursedFetter/actions.yml
@@ -22,7 +22,7 @@
   - type: SpellCastEffect
     effectProto: CursedFetterSpellCastEffectBeginner
   - type: MedievalInstantSpell
-  - type: InstantAction
+  - type: Action
     useDelay: 30
     itemIconStyle: BigAction
     sound: !type:SoundPathSpecifier
@@ -30,6 +30,7 @@
     icon:
       sprite: Imperial/Medieval/Magic/fetter-spell/action-cursed-fetter.rsi
       state: base
+  - type: InstantAction
     event: !type:MedievalSpawnInHandSpellEvent
       spawnedEntityPrototype: MedievalCursedFetter
       spellCastDoAfter:

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/FireFetter/actions.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/FireFetter/actions.yml
@@ -22,7 +22,7 @@
   - type: SpellCastEffect
     effectProto: FireFetterSpellCastEffectBeginner
   - type: MedievalInstantSpell
-  - type: InstantAction
+  - type: Action
     useDelay: 30
     itemIconStyle: BigAction
     sound: !type:SoundPathSpecifier
@@ -30,6 +30,7 @@
     icon:
       sprite: Imperial/Medieval/Magic/fetter-spell/action-fire-fetter.rsi
       state: base
+  - type: InstantAction
     event: !type:MedievalSpawnInHandSpellEvent
       spawnedEntityPrototype: MedievalFireFetter
       spellCastDoAfter:

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Light/HolyTouch/action.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Light/HolyTouch/action.yml
@@ -22,7 +22,7 @@
   - type: SpellCastEffect
     effectProto: HolyTouchSpellCastEffectBeginner
   - type: MedievalInstantSpell
-  - type: InstantAction
+  - type: Action
     useDelay: 30
     itemIconStyle: BigAction
     sound: !type:SoundPathSpecifier
@@ -30,6 +30,7 @@
     icon:
       sprite: Imperial/Medieval/Magic/holy_touch.rsi
       state: base
+  - type: InstantAction
     event: !type:MedievalSpawnInHandSpellEvent
       spawnedEntityPrototype: HolyTouch
       spellCastDoAfter:

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Light/Sunstrike/actions.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Light/Sunstrike/actions.yml
@@ -15,7 +15,7 @@
         bonusEssences:
           MagicMedievalFire: 1
   - type: MedievalTargetSpell
-  - type: WorldTargetAction
+  - type: Action
     useDelay: 80
     itemIconStyle: BigAction
     checkCanAccess: false
@@ -25,6 +25,10 @@
     icon:
       sprite: Imperial/Medieval/Gun/Charmer/sunstrike.rsi
       state: middle
+  - type: TargetAction
+    checkCanAccess: false
+    range: 60
+  - type: WorldTargetAction
     event: !type:MedievalProjectileSpellEvent
       projectilePrototype:
         0: MedievalProjectileSunstrikeSpotMiddle

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/IceDagger/actions.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/IceDagger/actions.yml
@@ -15,7 +15,7 @@
         bonusEssences:
           MagicMedievalVodka: 1
   - type: MedievalInstantSpell
-  - type: InstantAction
+  - type: Action
     useDelay: 4
     itemIconStyle: BigAction
     sound: !type:SoundPathSpecifier
@@ -23,6 +23,7 @@
     icon:
       sprite: Imperial/Medieval/Gun/Charmer/ice_dagger.rsi
       state: 1
+  - type: InstantAction
     event: !type:MedievalSpawnInHandSpellEvent
       spawnedEntityPrototype: IceDaggerBeginner
       spellCastDoAfter:

--- a/Resources/Prototypes/Imperial/Medieval/surrender.yml
+++ b/Resources/Prototypes/Imperial/Medieval/surrender.yml
@@ -4,7 +4,7 @@
   description: .
   components:
   - type: Action
-    cooldown: 30
+    useDelay: 30
     itemIconStyle: NoItem
     icon:
       sprite: Imperial/Medieval/Surrender/action.rsi


### PR DESCRIPTION
## О ПР`е
Тип: fix
Изменения: Исправлены ошибки, вызванные апстримом у CanSurrenderComponent, прототипа surrender и у прототипов заклинаний (FireFetter, HolyTouch, Sunstrike, IceDagger, CultDagger, CursedFetter)
## Технические детали
По какой-то причине, если использовать в компоненте Action cooldown, вместо useDelay, то это вызовет фатальную ошибку, которая крашит сервер ещё на моменте запуска

## Изменения кода официальных разработчиков
*Нет*
