### PR TITLE
Добавлен бросок существ из захвата (Grab Throw System)

### DIFF
--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -25,6 +25,7 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
+using Robust.Shared.Utility;
 
 namespace Content.Server.Hands.Systems
 {

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -24,7 +24,11 @@ using Robust.Shared.Physics.Components;
 using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
-using Robust.Shared.Utility;
+
+using Content.Shared.Imperial.Medieval.Grab.Components;
+using Content.Server.Popups;
+using Content.Shared.Imperial.Medieval.Grab.Systems;
+using Content.Server.Imperial.Medieval.Grab;
 
 namespace Content.Server.Hands.Systems
 {
@@ -37,6 +41,10 @@ namespace Content.Server.Hands.Systems
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
         [Dependency] private readonly PullingSystem _pullingSystem = default!;
         [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
+        [Dependency] private readonly PopupSystem _popupSystem = default!;
+        [Dependency] private readonly GrabSystem _grab = default!;
+        [Dependency] private readonly GrabThrowSystem _grabThrowSystem = default!;
+
 
         private EntityQuery<PhysicsComponent> _physicsQuery;
 
@@ -144,6 +152,11 @@ namespace Content.Server.Hands.Systems
         {
             if (playerSession?.AttachedEntity is not {Valid: true} player || !Exists(player) || !coordinates.IsValid(EntityManager))
                 return false;
+
+            // Start Imperial Medieval Code ThrowGrabbed
+            if (_grabThrowSystem.TryThrowGrabbed(player, coordinates))
+                return true;
+            // End Imperial Medieval Code
 
             return ThrowHeldItem(player, coordinates);
         }

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -1,4 +1,5 @@
 using System.Numerics;
+using Content.Server.Imperial.Medieval.Grab;
 using Content.Server.Inventory;
 using Content.Server.Stack;
 using Content.Server.Stunnable;
@@ -25,11 +26,6 @@ using Robust.Shared.Player;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
 
-using Content.Shared.Imperial.Medieval.Grab.Components;
-using Content.Server.Popups;
-using Content.Shared.Imperial.Medieval.Grab.Systems;
-using Content.Server.Imperial.Medieval.Grab;
-
 namespace Content.Server.Hands.Systems
 {
     public sealed class HandsSystem : SharedHandsSystem
@@ -41,8 +37,6 @@ namespace Content.Server.Hands.Systems
         [Dependency] private readonly SharedTransformSystem _transformSystem = default!;
         [Dependency] private readonly PullingSystem _pullingSystem = default!;
         [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
-        [Dependency] private readonly PopupSystem _popupSystem = default!;
-        [Dependency] private readonly GrabSystem _grab = default!;
         [Dependency] private readonly GrabThrowSystem _grabThrowSystem = default!;
 
 

--- a/Content.Server/Hands/Systems/HandsSystem.cs
+++ b/Content.Server/Hands/Systems/HandsSystem.cs
@@ -39,7 +39,6 @@ namespace Content.Server.Hands.Systems
         [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
         [Dependency] private readonly GrabThrowSystem _grabThrowSystem = default!;
 
-
         private EntityQuery<PhysicsComponent> _physicsQuery;
 
         /// <summary>

--- a/Content.Server/Imperial/Medieval/Grab/GrabThrowSystem.cs
+++ b/Content.Server/Imperial/Medieval/Grab/GrabThrowSystem.cs
@@ -41,9 +41,9 @@ public sealed class GrabThrowSystem : EntitySystem
 
         float throwDistance = 3.0f;
         if (levelStrength > 10)
-            throwDistance += (levelStrength - 10) * 0.33f;
+            throwDistance += (levelStrength - 10) * 0.33f; // За каждый уровень силы больше 10 прибавляем 0.33 к дальности броска
         else if (levelStrength < 10)
-            throwDistance -= (10 - levelStrength) * 0.25f;
+            throwDistance -= (10 - levelStrength) * 0.25f; // За каждый уровень силы меньше 10 отбавляем 0.25 к дальности броска
 
         throwDistance = MathF.Max(throwDistance, 0.5f);
 

--- a/Content.Server/Imperial/Medieval/Grab/GrabThrowSystem.cs
+++ b/Content.Server/Imperial/Medieval/Grab/GrabThrowSystem.cs
@@ -1,0 +1,79 @@
+using Content.Server.Popups;
+using Content.Shared.Imperial.Medieval.Grab.Components;
+using Content.Shared.Imperial.Medieval.Grab.Systems;
+using Content.Shared.Imperial.Medieval.Skills;
+using Content.Shared.Throwing;
+using Robust.Server.Audio;
+using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
+using Robust.Shared.Audio;
+
+namespace Content.Server.Imperial.Medieval.Grab;
+
+public sealed class GrabThrowSystem : EntitySystem
+{
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly ThrowingSystem _throwing = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly GrabSystem _grab = default!;
+    [Dependency] private readonly AudioSystem _audio = default!;
+
+    /// <summary>
+    /// Попытка бросить существо, удерживаемый игроком в грабе.
+    /// </summary>
+    public bool TryThrowGrabbed(EntityUid player, EntityCoordinates target)
+    {
+        // Проверяем, есть ли у игрока активный граб
+        if (!TryComp<GrabberComponent>(player, out var grabber) ||
+            grabber.GrabbedEntity is not { Valid: true } grabbed)
+            return false;
+
+        if (!HasComp<PhysicsComponent>(grabbed))
+            return false;
+
+        if (TryComp<GrabbableComponent>(grabbed, out var grabbable))
+            _grab.TryStopGrab(grabbed, grabbable, player);
+
+        // Определяем силу по навыку Strength
+        int levelStrength = 10;
+        if (TryComp<SkillsComponent>(player, out var skills))
+            skills.Levels.TryGetValue(SharedSkillsSystem.StrengthId, out levelStrength);
+
+        float throwDistance = 3.0f;
+        if (levelStrength > 10)
+            throwDistance += (levelStrength - 10) * 0.33f;
+        else if (levelStrength < 10)
+            throwDistance -= (10 - levelStrength) * 0.25f;
+
+        throwDistance = MathF.Max(throwDistance, 0.5f);
+
+        var grabbedPos = _transform.GetMapCoordinates(grabbed).Position;
+        var targetPos = _transform.ToMapCoordinates(target).Position;
+        var dirVector = targetPos - grabbedPos;
+
+        if (dirVector.Length() > throwDistance)
+            dirVector = dirVector.Normalized() * throwDistance;
+
+        float baseThrowSpeed = (dirVector.Length() / 3f) * 10f;
+
+        _audio.PlayPvs(new SoundPathSpecifier("/Audio/Effects/thudswoosh.ogg"), grabbed);
+        _throwing.TryThrow(
+            grabbed,
+            dirVector,
+            baseThrowSpeed: baseThrowSpeed,
+            user: player,
+            pushbackRatio: 2f,
+            recoil: false,
+            playSound: true,
+            doSpin: false
+        );
+
+        _popup.PopupEntity(
+            Loc.GetString("grab-throw-success", ("target", MetaData(grabbed).EntityName)),
+            player,
+            player
+        );
+
+        return true;
+    }
+}

--- a/Resources/Locale/ru-RU/Imperial/Medieval/verbs/grab.ftl
+++ b/Resources/Locale/ru-RU/Imperial/Medieval/verbs/grab.ftl
@@ -1,3 +1,4 @@
 grab-escape-success = Вам удалось вырваться из захвата!
 grab-popup-success = Вы схватили цель!
 grabbed-popup = Кто-то вас схватил!
+grab-throw-success = Вы с силой швырнули { $target }!


### PR DESCRIPTION
## О ПР`е

Теперь игрок может бросить удерживаемую цель на расстояние, зависящее от уровня силы (`Strength`). При броске проигрывается звуковой эффект и появляется уведомление с именем брошенной цели.

## Технические детали
* Добавлен новый класс `GrabThrowSystem`
* Добавлена интеграция с `HandsSystem` для вызова броска при действии `ThrowItem`
* Добавлен локализованный popup-сообщение:
  `grab-throw-success = Вы с силой швырнули { $target }!`
* Проигрывается звук `/Audio/Effects/thudswoosh.ogg` при успешном броске

## Изменения кода официальных разработчиков

В `Content.Server/Hands/Systems/HandsSystem.cs` добавлено одно новое условие в `HandleThrowItem`

## Медиа
<img width="518" height="167" alt="image" src="https://github.com/user-attachments/assets/28e59c8a-d748-4e8d-974b-f360aede00d8" />

### Дальность броска
<img width="870" height="582" alt="image" src="https://github.com/user-attachments/assets/b1749cc2-1bf6-4b4f-ab49-305ea757357f" />
