### PR TITLE
Фикс магической искры

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/MagicSpark/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/MagicSpark/projectiles.yml
@@ -14,12 +14,29 @@
     igniteTime: 1
     igniteChance: 1
     flammableStacks: 0.5
+  - type: TimedDespawn
+    lifetime: 6
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Heat: 5
   - type: Fixtures
     fixtures:
       fix1:
         shape:
           !type:PhysShapeCircle
           radius: 0.15
+        density: 60
+        mask:
+        - ItemMask
+        restitution: 0.3
+        friction: 0.2
+      ignition:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.15
+        density: 60
+        mask:
         layer:
           - HighImpassable
           - MidImpassable
@@ -27,17 +44,14 @@
           - BulletImpassable
           - Opaque
         hard: false
-  - type: TimedDespawn
-    lifetime: 6
-  - type: DamageOtherOnHit
-    damage:
-      types:
-        Heat: 5
   - type: ThrowingAngle
     angle: 0
   - type: EmitSoundOnLand
     sound:
       path: /Audio/Imperial/Medieval/craft_foundry.ogg
   - type: IgniteOnCollide
-    fixtureId: fix1
     fireStacks: 1
+  - type: Item
+  - type: Physics
+    bodyType: Dynamic
+    fixedRotation: false

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/MagicSpark/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/MagicSpark/projectiles.yml
@@ -14,6 +14,30 @@
     igniteTime: 1
     igniteChance: 1
     flammableStacks: 0.5
-  - type: Unremoveable
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.15
+        layer:
+          - HighImpassable
+          - MidImpassable
+          - LowImpassable
+          - BulletImpassable
+          - Opaque
+        hard: false
   - type: TimedDespawn
     lifetime: 6
+  - type: DamageOtherOnHit
+    damage:
+      types:
+        Heat: 5
+  - type: ThrowingAngle
+    angle: 0
+  - type: EmitSoundOnLand
+    sound:
+      path: /Audio/Imperial/Medieval/craft_foundry.ogg
+  - type: IgniteOnCollide
+    fixtureId: fix1
+    fireStacks: 1

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/MagicSpark/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/MagicSpark/projectiles.yml
@@ -2,7 +2,6 @@
 
 - type: entity
   id: SparkBeginner
-  parent: BaseItem
   components:
   - type: Sprite
     sprite: Imperial/Medieval/Magic/Fire/MagicSpark/projectiles.rsi
@@ -37,6 +36,7 @@
           radius: 0.15
         density: 60
         mask:
+          - MachineMask
         layer:
           - HighImpassable
           - MidImpassable

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/MagicSpark/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/MagicSpark/projectiles.yml
@@ -52,6 +52,7 @@
   - type: IgniteOnCollide
     fireStacks: 1
   - type: Item
+    size: Ginormous
   - type: Physics
     bodyType: Dynamic
     fixedRotation: false


### PR DESCRIPTION
## О ПР`е
Тип: fix
Изменения: Магическую искру теперь можно метать для нанесения урона. При попадании поджигает. Суммарный урон чуть меньше чем у Т1 магической стрелы

## Технические детали
*Нет*

## Изменения кода официальных разработчиков
*Нет*
