### PR TITLE
fix: Jobs & bombs

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/Fireball/effect.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/Fireball/effect.yml
@@ -47,7 +47,7 @@
     noRot: true
     layers:
      - state: middle
-      shader: unshaded
+       shader: unshaded
   - type: PointLight
     radius: 3
     energy: 2

--- a/Resources/Prototypes/Imperial/Medieval/jobs.yml
+++ b/Resources/Prototypes/Imperial/Medieval/jobs.yml
@@ -2484,18 +2484,18 @@
     components:
     - type: WarningOnAttach
       message: medieval-warning-leg
-    - type: MedievalFactionMember
-      faction: Legion
-      factionMenuAction: LegionFactionMenuAction
+    # - type: MedievalFactionMember
+    #   faction: Legion
+    #   factionMenuAction: LegionFactionMenuAction
     #- type: IdentityFaction
     #  faction: Insurgency
     - type: MedievalJobSpawn
-      spawnType: Legion
+      spawnType: LegionTrader
     - type: GiveItemObjective
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective400800
     - type: MedievalPasportPerson
-      personJob: "[color=red]Алхимик легиона[/color]"
+      personJob: "[color=red]Алхимик южных земель[/color]"
       pasport: MedievalPasportLegion
       jobPrefix: "[АлхимикЛ]"
     - type: MedievalPotionChecker
@@ -3056,18 +3056,18 @@
     components:
     - type: WarningOnAttach
       message: medieval-warning-ins
-    - type: MedievalFactionMember
-      faction: Insurgency
-      factionMenuAction: InsurgencyFactionMenuAction
+    # - type: MedievalFactionMember
+    #   faction: Insurgency
+    #   factionMenuAction: InsurgencyFactionMenuAction
     #- type: IdentityFaction
     #  faction: Insurgency
     - type: MedievalJobSpawn
-      spawnType: Insurgency
+      spawnType: InsurgencyTrader
     - type: GiveItemObjective
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective400800
     - type: MedievalPasportPerson
-      personJob: "[color=red]Алхимик мятежников[/color]"
+      personJob: "[color=red]Алхимик северных земель[/color]"
       pasport: MedievalPasportInsurgency
       jobPrefix: "[АлхимикМ]"
     - type: MedievalPotionChecker
@@ -4631,9 +4631,9 @@
     - type: WarningOnAttach
       message: medieval-warning-base
     - type: CrafterTrait
-    - type: MedievalFactionMember
-      faction: Legion
-      factionMenuAction: LegionFactionMenuAction
+    # - type: MedievalFactionMember
+    #   faction: Legion
+    #   factionMenuAction: LegionFactionMenuAction
     #- type: IdentityFaction
     #  faction: Legion
     - type: MedievalJobSpawn
@@ -4642,7 +4642,7 @@
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective5001000
     - type: MedievalPasportPerson
-      personJob: "[color=cyan]Кузнец легиона[/color]"
+      personJob: "[color=cyan]Кузнец южных земель[/color]"
       pasport: MedievalPasportLegion
       jobPrefix: "[КузЛ]"
 
@@ -4690,9 +4690,9 @@
     - type: WarningOnAttach
       message: medieval-warning-base
     - type: CrafterTrait
-    - type: MedievalFactionMember
-      faction: Insurgency
-      factionMenuAction: InsurgencyFactionMenuAction
+    # - type: MedievalFactionMember
+    #   faction: Insurgency
+    #   factionMenuAction: InsurgencyFactionMenuAction
     #- type: IdentityFaction
     #  faction: Insurgency
     - type: MedievalJobSpawn
@@ -4701,7 +4701,7 @@
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective5001000
     - type: MedievalPasportPerson
-      personJob: "[color=red]Кузнец мятежников[/color]"
+      personJob: "[color=red]Кузнец северных земель[/color]"
       pasport: MedievalPasportInsurgency
       jobPrefix: "[КузМ]"
 
@@ -4748,9 +4748,9 @@
     - type: WarningOnAttach
       message: medieval-warning-base
     - type: CrafterTrait
-    - type: MedievalFactionMember
-      faction: Legion
-      factionMenuAction: LegionFactionMenuAction
+    # - type: MedievalFactionMember
+    #   faction: Legion
+    #   factionMenuAction: LegionFactionMenuAction
     #- type: IdentityFaction
     #  faction: Legion
     - type: MedievalJobSpawn
@@ -4759,7 +4759,7 @@
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective5001000
     - type: MedievalPasportPerson
-      personJob: "[color=cyan]Подмастерье кузнеца легиона[/color]"
+      personJob: "[color=cyan]Подмастерье кузнеца южных земель[/color]"
       pasport: MedievalPasportLegion
       jobPrefix: "[МлКузЛ]"
 
@@ -4806,9 +4806,9 @@
     - type: WarningOnAttach
       message: medieval-warning-base
     - type: CrafterTrait
-    - type: MedievalFactionMember
-      faction: Insurgency
-      factionMenuAction: InsurgencyFactionMenuAction
+    # - type: MedievalFactionMember
+    #   faction: Insurgency
+    #   factionMenuAction: InsurgencyFactionMenuAction
     #- type: IdentityFaction
     #  faction: Insurgency
     - type: MedievalJobSpawn
@@ -4817,7 +4817,7 @@
     - type: MoneyCollector
       objectivePrototype: MedievalGetMoneyObjective5001000
     - type: MedievalPasportPerson
-      personJob: "[color=red]Подмастерье кузнеца мятежников[/color]"
+      personJob: "[color=red]Подмастерье кузнеца северных земель[/color]"
       pasport: MedievalPasportInsurgency
       jobPrefix: "[МлКузМ]"
 

--- a/Resources/Prototypes/Imperial/Medieval/jobs.yml
+++ b/Resources/Prototypes/Imperial/Medieval/jobs.yml
@@ -1909,7 +1909,7 @@
     #- type: IdentityFaction
     #  faction: Legion
     - type: MedievalJobSpawn
-      spawnType: LegionJailer
+      spawnType: Legion
     - type: MedievalPasportPerson
       personJob: "[color=cyan]Тюремщик легиона[/color]"
       pasport: MedievalPasportLegion

--- a/Resources/Prototypes/Imperial/Medieval/medieval.yml
+++ b/Resources/Prototypes/Imperial/Medieval/medieval.yml
@@ -1069,6 +1069,8 @@
   - type: RDWeight
     value: 2
   - type: ExplodeOnTrigger
+    keysIn:
+    - timer
   - type: Explosive
     explosionType: MedievalDefault
     maxIntensity: 4
@@ -1080,7 +1082,6 @@
     layers:
     - state: icon
       map: ["enum.TriggerVisualLayers.Base"]
-  - type: TriggerOnUse
   - type: TimerTrigger
     delay: 2.5
     beepSound:
@@ -1090,6 +1091,8 @@
     initialBeepDelay: 0
     beepInterval: 6 # 2 beeps total (at 0 and 2)
   - type: SpawnOnTrigger
+    keysIn:
+    - timer
     proto: MedievalExplosionEffect
 
 - type: entity


### PR DESCRIPTION
## О ПР`е
Тип: fix
Изменения: Алхимики и кузнецы больше не отображаются в панели управления фракцией. Спавн алхимиков перенесён к торговцам. Тюремщик легиона теперь спавнится там же, где и все легионеры. Исправлена пороховая бомбочка.

## Технические детали
*Нет*

## Изменения кода официальных разработчиков
*Нет*
