### PR TITLE
Маг. кузня, факел и жаровня

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/decor.yml
+++ b/Resources/Prototypes/Imperial/Medieval/decor.yml
@@ -1133,13 +1133,12 @@
         density: 190
         mask:
         - SmallMobMask
-        layer:
-        - MachineLayer
   - type: PointLight
     color: Orange
     radius: 12
     energy: 2.3
   - type: Anchorable
+  - type: AlwaysHot
   - type: AmbientSound
     volume: -15
     range: 1.5
@@ -1175,8 +1174,6 @@
         density: 190
         mask:
         - SmallMobMask
-        layer:
-        - MachineLayer
   - type: PointLight
     color: Orange
     radius: 18

--- a/Resources/Prototypes/Imperial/Medieval/mainshop.yml
+++ b/Resources/Prototypes/Imperial/Medieval/mainshop.yml
@@ -568,6 +568,17 @@
   - MedievalBuild
 
 - type: listing
+  id: MdvShopMedievalWizardBlacksmithCraft
+  productEntity: MedievalWizardBlacksmithCraft
+  discountCategory: medievalDiscounts
+  discountDownTo:
+    Revent: 50
+  cost:
+    Revent: 75
+  categories:
+  - MedievalBuild
+
+- type: listing
   id: MdvShopMedievalMeltingPlaceCraft
   productEntity: MedievalMeltingPlaceCraft
   discountCategory: medievalDiscounts

--- a/Resources/Prototypes/Imperial/Medieval/shop_demo.yml
+++ b/Resources/Prototypes/Imperial/Medieval/shop_demo.yml
@@ -299,6 +299,14 @@
   - MedievalBuildDemo
 
 - type: listing
+  id: DemoMdvShopMedievalWizardBlacksmithCraft
+  productEntity: MedievalWizardBlacksmithCraft
+  cost:
+    UnknownMedieval: 1
+  categories:
+  - MedievalBuildDemo
+
+- type: listing
   id: DemoMdvShopMedievalMeltingPlaceCraft
   productEntity: MedievalMeltingPlaceCraft
   cost:

--- a/Resources/Prototypes/Imperial/Medieval/trade_guilds.yml
+++ b/Resources/Prototypes/Imperial/Medieval/trade_guilds.yml
@@ -1516,6 +1516,9 @@
   - productEntity: MedievalKotel
     cost: 50
     reputationForBuying: 1.7
+  - productEntity: MedievalWizardBlacksmithCraft
+    cost: 75
+    reputationForBuying: 1.7
   - productEntity: MedievalWoodenFloorCraft
     cost: 10
     reputationForBuying: 0.3


### PR DESCRIPTION
## О ПР`е

Тип: tweak

Изменения: Заготовка маг. кузни добавлена в торговую дыру, жаровня и факел больше не закрывают проход(никакого абуза мобов ими), от жаровни теперь можно зажечь факелы.

## Технические детали

*Нет*

## Изменения кода официальных разработчиков

*Нет*
