### PR TITLE
Изменение факела на колонне

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/decor.yml
+++ b/Resources/Prototypes/Imperial/Medieval/decor.yml
@@ -1176,8 +1176,8 @@
         - SmallMobMask
   - type: PointLight
     color: Orange
-    radius: 18
-    energy: 1.35
+    radius: 5
+    energy: 4
   - type: Anchorable
   - type: AlwaysHot
   - type: AmbientSound


### PR DESCRIPTION
## О ПР`е
Тип: tweak
Изменения: Факел на колонне теперь почти не отличается по яркости от обычного факела.

_Если же вы считаете, что данное изменение сильно повлияет на освещение в городе, есть вариант добавить магические фонари, которые будут идентичны по яркости нынешним факелам на колоннах, но их нельзя будет создавать или сдвигать с места._

_Предложение: https://discord.com/channels/1040938900039929917/1453077358457389249/1453077358457389249_

<details>
  <summary>До:</summary>

![Do](https://github.com/user-attachments/assets/c5eb85ce-533b-4f71-a282-bc612369c95f)
</details>

<details>
  <summary>После:</summary>

![Posle](https://github.com/user-attachments/assets/f5bc00f2-4665-431e-b9e4-2e82d70d3db9)
</details>

## Технические детали
*Нет*

## Изменения кода официальных разработчиков
*Нет*
