### PR TITLE
Регенерация культистам истины

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/jobs.yml
+++ b/Resources/Prototypes/Imperial/Medieval/jobs.yml
@@ -5095,6 +5095,23 @@
       personJob: "[color=red]Культист[/color]"
       pasport: no
       jobPrefix: "[Культ]"
+    - type: PassiveDamage # Этот компонент имитирует лечение от связи с культом (CultCursedComponent) + стандартное пассивное лечение
+      allowedStates:
+      - Alive
+      damageCap: 100
+      damage:
+        types:
+          Asphyxiation: -0.11
+          Bloodloss: -0.13
+          Blunt: -0.15
+          Heat: -0.12
+          Piercing: -0.18
+          Poison: -0.08
+          Slash: -0.23
+          Shock: -0.08
+          Radiation: -0.08
+          Cold: -0.08
+          Cellular: -0.08
 
 # MEDIEVAL CultLeader
 
@@ -5171,6 +5188,23 @@
     - type: CloackMessage
       action: CloackMessageActionIns
       faction: "cult"
+    - type: PassiveDamage # Этот компонент имитирует лечение от связи с культом (CultCursedComponent) + стандартное пассивное лечение
+      allowedStates:
+      - Alive
+      damageCap: 100
+      damage:
+        types:
+          Asphyxiation: -0.11
+          Bloodloss: -0.13
+          Blunt: -0.15
+          Heat: -0.12
+          Piercing: -0.18
+          Poison: -0.08
+          Slash: -0.23
+          Shock: -0.08
+          Radiation: -0.08
+          Cold: -0.08
+          Cellular: -0.08
 
 # MEDIEVAL Villager REGULAR
 


### PR DESCRIPTION
## О ПР`е
Тип: tweak
Изменения: Теперь все члены культа истины обладают регенерацией, аналогичной регенерации при связи с культом.

## Почему?
Очень странно, что обыкновенные люди, которые прошли какой-то там ритуал, имеют регенерацию, а полноценные члены культа - нет.
На мой взгляд, это не должно сильно повлиять на баланс, так как лечение достаточно слабое.

## Технические детали
Теперь все культисты получают компонент `PassiveDamage`, который имитирует лечение от связи с культом (`CultCursedComponent`) + стандартное пассивное лечение.
_(Я учел, что `PassiveDamageComponent` и `CultCursedComponent` лечат через разные промежутки времени (первый - каждую секунду, второй - каждые 10 секунд), и изменил значения регенерации соответственно)_

## Изменения кода официальных разработчиков
*Нет*
