### PR TITLE
Одежду Necro скелетов больше нельзя снять

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/clothes.yml
+++ b/Resources/Prototypes/Imperial/Medieval/clothes.yml
@@ -162,6 +162,7 @@
   - type: ContainerContainer
     containers:
       toggleable-clothing: !type:ContainerSlot {}
+  - type: Unremoveable
   #- type: Armor
   #  modifiers:
   #    coefficients:


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

<!--
    Тип изменения, может быть одним из следующих:
    - feat
    - tweak
    - fix
    - remove

    Ставьте feat, если вы что-то добавили.
    Ставьте tweak, если вы изменили баланс или механику.
    Ставьте fix, если это исправление чего-то.
    Ставьте remove, если вы что-то удалили или ревертнули

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда ставьте feat
-->
Тип: fix
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения:
Существовал баг, когда темные последователи/защитники каравана просто снимали свою униформу, из-за чего их проклятая метка выпадала. Исправлено.
<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

*Нет*

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*
