### PR TITLE
Двери VS Скелеты

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/mobs.yml
+++ b/Resources/Prototypes/Imperial/Medieval/mobs.yml
@@ -2921,6 +2921,8 @@
     - id: MedievalMagicStoneRandom
       amount: 1
       prob: 0.09
+  - type: Hands
+  - type: ComplexInteraction
 
 - type: entity
   name: fighter skeleton
@@ -3013,6 +3015,8 @@
     - id: MedievalMagicStoneRandom
       amount: 1
       prob: 0.16
+  - type: Hands
+  - type: ComplexInteraction
 
 - type: entity
   name: legion skeleton
@@ -3234,6 +3238,8 @@
       amount: 1
       prob: 0.17
   - type: MedievalUnthrowable
+  - type: Hands
+  - type: ComplexInteraction
 
 - type: entity
   name: skeleton with a mace
@@ -3290,6 +3296,8 @@
     - id: MedievalMagicStoneRandom
       amount: 1
       prob: 0.17
+  - type: Hands
+  - type: ComplexInteraction
 
 - type: entity
   name: skeleton with a spear
@@ -3349,6 +3357,8 @@
     - id: MedievalMagicStoneRandom
       amount: 1
       prob: 0.17
+  - type: Hands
+  - type: ComplexInteraction
 
 - type: entity
   name: skeleton with a halberd
@@ -3405,6 +3415,8 @@
     - id: MedievalMagicStoneRandom
       amount: 1
       prob: 0.17
+  - type: Hands
+  - type: ComplexInteraction
 
 - type: entity
   name: skeleton with a dagger


### PR DESCRIPTION
## О ПР`е

Тип: tweak

Изменения: Скелеты некрополя теперь могут открывать двери и сундуки


## Технические детали

Добавила им ручки как у ксеноморфов с ванили, могут открывать/закрывать всякое, кнопочки жмакать и тд.

## Изменения кода официальных разработчиков

*Нет*
