### PR TITLE
Стаминарезист медальону устойчивости

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/medieval.yml
+++ b/Resources/Prototypes/Imperial/Medieval/medieval.yml
@@ -1474,6 +1474,8 @@
         Blunt: 0.85
         Slash: 0.85
         Piercing: 0.85
+  - type: StaminaResistance
+    damageCoefficient: 0.85
   #- type: QualityOfItem
   #  qualityWeights:
   #    0: 0

--- a/Resources/Prototypes/Imperial/Medieval/medieval.yml
+++ b/Resources/Prototypes/Imperial/Medieval/medieval.yml
@@ -1401,6 +1401,9 @@
     accent: NoSlip
   - type: StealTarget # imperial medieval
     stealGroup: MedievalGetMedaljonNoslip # imperial medieval
+  - type: Armor
+  - type: StaminaResistance
+    damageCoefficient: 0.7
 
 - type: entity
   parent: MedaljonFlashImmune
@@ -1474,8 +1477,6 @@
         Blunt: 0.85
         Slash: 0.85
         Piercing: 0.85
-  - type: StaminaResistance
-    damageCoefficient: 0.85
   #- type: QualityOfItem
   #  qualityWeights:
   #    0: 0

--- a/Resources/Prototypes/Imperial/Medieval/medieval.yml
+++ b/Resources/Prototypes/Imperial/Medieval/medieval.yml
@@ -1402,6 +1402,11 @@
   - type: StealTarget # imperial medieval
     stealGroup: MedievalGetMedaljonNoslip # imperial medieval
   - type: Armor
+    modifiers:
+      coefficients:
+        Blunt: 0.99
+        Slash: 0.99
+        Piercing: 0.99
   - type: StaminaResistance
     damageCoefficient: 0.7
 


### PR DESCRIPTION
## О ПР`е

Тип: tweak

Изменения: Медальон с чарами устойчивости получил 30% защиты от стаминаурона. Реализация предложки от fortengamer.

## Технические детали

Пришлось дать компонент armor хоть с какой-то защитой, чтобы стаминарезист отображался.

## Изменения кода официальных разработчиков

*Нет*
<img width="513" height="223" alt="image" src="https://github.com/user-attachments/assets/774bbc8f-83ea-4e26-8f8f-3d43053087ce" />
