### PR TITLE
meat fish worm

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Tools/tools.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/tools.yml
@@ -486,6 +486,7 @@
   - type: StaticPrice
     price: 25
   - type: Shovel
+  - type: Sharp # Imperial Medieval
 
 - type: entity
   parent: BaseItem

--- a/Resources/Prototypes/Imperial/Medieval/Fishing/fish.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Fishing/fish.yml
@@ -7,6 +7,7 @@
   - type: Tag
     tags:
     - fish
+    - Meat
   - type: SolutionContainerManager
     solutions:
       food:
@@ -117,6 +118,7 @@
   - type: Tag
     tags:
     - fish
+    - Meat
   - type: Item
     size: Small
   - type: SolutionContainerManager


### PR DESCRIPTION
## О ПР`е

Тип: fix

Изменения: Мясоеды (унатхи и орки) теперь могут есть рыбу. В теории теперь лопатой тоже можно копать червей, к сожалению на локалке проверить это не удалось.

## Технические детали

*Добавлен тег Meat рыбе, лопате добавлен компонент Sharp*

## Изменения кода официальных разработчиков

*Нет*
