### PR TITLE
Fix Cursed Skeleton Horse taking Radiation Damage

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/transport.yml
+++ b/Resources/Prototypes/Imperial/Medieval/transport.yml
@@ -349,12 +349,19 @@
     accelerationTime: 8
     maxSpeedModifier: 1.76
 
+- type: damageModifierSet
+  id: MedievalSkeletonHorseDamageModifierSet
+  coefficients:
+    Radiation: 0
+
 - type: entity
   parent: MedievalHorseTransport
   id: MedievalSkeletonHorseTransport
   name: horse
   description: MedievalSkeletonHorseTransport
   components:
+  - type: Damageable
+    damageModifierSet: MedievalSkeletonHorseDamageModifierSet
   - type: Bloodstream
     bloodMaxVolume: 0
   - type: Sprite


### PR DESCRIPTION

<img width="1281" height="562" alt="image" src="https://github.com/user-attachments/assets/5d8d77b1-b7d8-413f-9d76-5806d0f0058d" />


## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->


Тип: fix
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения: The skeleton horse is now immune to radiation damage

<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

- Added a  damage modifier set with 0 Radiation coefficient to MedievalSkeletonHorseTransport

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*