### PR TITLE
Фикс регистра «me» в орочьем акценте

### DIFF
--- a/Content.Server/Imperial/Medieval/Species/OrcAccentSystem.cs
+++ b/Content.Server/Imperial/Medieval/Species/OrcAccentSystem.cs
@@ -68,6 +68,18 @@ public sealed class OrcAccentSystem : EntitySystem
         return dest;
     }
 
+    // Перед текущим словом либо ничего, либо конец прошлого предложения.
+    public static bool AtSentenceStart(StringBuilder text)
+    {
+        for (var i = text.Length - 1; i >= 0; i--)
+        {
+            if (char.IsWhiteSpace(text[i]))
+                continue;
+            return text[i] is '.' or '!' or '?';
+        }
+        return true;
+    }
+
     public string ToInfinitive(string word)
     {
         var lower = word.ToLower();
@@ -132,6 +144,14 @@ public sealed class OrcAccentSystem : EntitySystem
             {
                 var pronoun = name == null ? "моя" : name;
                 result.Append(MatchCase(element, pronoun.Substring(0, 1))).Append(pronoun.Substring(1));
+                continue;
+            }
+
+            // Замена "I": SanitizeMessageCapitalizeTheWordI всегда приводит его к заглавному, поэтому регистр берём из позиции в предложении, а не из исходного слова.
+            if (element is "I" or "i")
+            {
+                var pronoun = name ?? "me";
+                result.Append(AtSentenceStart(result) ? char.ToUpper(pronoun[0]) : pronoun[0]).Append(pronoun[1..]);
                 continue;
             }
 


### PR DESCRIPTION
## О ПР`е

Тип: fix
Изменения: Орочий акцент перестал писать местоимение «me» капсом в середине предложения

## Технические детали

Обработка «I» лежит в `OrcAccentSystem` рядом с заменой «я», а не в словарных заменах. Причина: `ReplacementAccentSystem` тянет регистр от исходного слова, а `SanitizeMessageCapitalizeTheWordI` ещё до акцента всегда делает «i» заглавным, поэтому через словарь местоимение вылезало как «Me»/«ME» в любом месте предложения.

Регистр теперь считается от позиции в предложении: `me` в середине, `Me` в начале и после `.`, `!`, `?`. Неграмотные орки, как и раньше, подставляют своё имя вместо местоимения.

Тест на определение начала предложения: `Content.Tests/Server/Speech/OrcAccentTest.cs`.

## Изменения кода официальных разработчиков

*Нет*