### PR TITLE
Ряд фиксов в ПР апстрима

### DIFF
--- a/.github/workflows/build-test-debug.yml
+++ b/.github/workflows/build-test-debug.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    if: false
+    if: github.actor != 'PJBot' && github.event.pull_request.draft == false
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/Content.Server/Imperial/Medieval/Power/EntitySystems/MyrmexPipeSystem.cs
+++ b/Content.Server/Imperial/Medieval/Power/EntitySystems/MyrmexPipeSystem.cs
@@ -69,12 +69,15 @@ public sealed class MyrmexPipeSystem : EntitySystem
         if (args.Handled || args.Cancelled)
             return;
 
-        if (!_nodeContainer.TryGetNode<MyrmexPipeNode>(pipe.Owner, pipe.Comp.NodeId, out var pipeNode))
+        if (!_nodeContainer.TryGetNode<MyrmexPipeNode>(pipe.Owner, pipe.Comp.NodeId, out var pipeNode)
+            || !CanRefloodNode(pipe.Owner, pipeNode))
             return;
 
         pipeNode.Enabled ^= true;
 
-        _nodeGroupSystem.QueueReflood(pipeNode);
+        if (CanRefloodNode(pipe.Owner, pipeNode))
+            _nodeGroupSystem.QueueReflood(pipeNode);
+
         _appearance.SetData(pipe, MyrmexValveVisuals.State, pipeNode.Enabled);
 
         args.Handled = true;
@@ -239,7 +242,34 @@ public sealed class MyrmexPipeSystem : EntitySystem
             cable1
         );
 
-        QueueDel(cable1);
-        QueueDel(cable2);
+        QueueNodeContainerDeletion(cable1);
+        QueueNodeContainerDeletion(cable2);
+    }
+
+    private bool CanRefloodNode(EntityUid uid, Node node)
+    {
+        return node.Owner == uid
+            && !node.Deleting
+            && !TerminatingOrDeleted(uid)
+            && !EntityManager.IsQueuedForDeletion(uid)
+            && HasComp<TransformComponent>(uid);
+    }
+
+    private void QueueNodeContainerDeletion(EntityUid uid)
+    {
+        if (TerminatingOrDeleted(uid))
+            return;
+
+        if (TryComp<NodeContainerComponent>(uid, out var container))
+        {
+            foreach (var node in container.Nodes.Values)
+            {
+                node.Deleting = true;
+                _nodeGroupSystem.QueueNodeRemove(node);
+            }
+        }
+
+        if (!EntityManager.IsQueuedForDeletion(uid))
+            QueueDel(uid);
     }
 }

--- a/Content.Server/Imperial/Medieval/Power/EntitySystems/RandomPowerSystem.cs
+++ b/Content.Server/Imperial/Medieval/Power/EntitySystems/RandomPowerSystem.cs
@@ -50,8 +50,12 @@ public sealed class RandomPowerSystem : EntitySystem
             _prototypeVoltages[prototypeId] = voltage;
         }
 
-        if (!_nodeContainer.TryGetNode<Node>(ent.Owner, ent.Comp.Node, out var node))
+        if (!_nodeContainer.TryGetNode<Node>(ent.Owner, ent.Comp.Node, out var node)
+            || !CanRefloodNode(ent.Owner, node))
             return;
+
+        if (node.NodeGroup != null)
+            _nodeGroupSystem.QueueNodeRemove(node);
 
         node.SetNodeGroupID(voltage);
 
@@ -64,6 +68,16 @@ public sealed class RandomPowerSystem : EntitySystem
         var state = ent.Comp.AvailableVoltages[voltage];
         _appearance.SetData(ent, RandomPowerVisuals.Voltage, state);
 
-        _nodeGroupSystem.QueueReflood(node);
+        if (CanRefloodNode(ent.Owner, node))
+            _nodeGroupSystem.QueueReflood(node);
+    }
+
+    private bool CanRefloodNode(EntityUid uid, Node node)
+    {
+        return node.Owner == uid
+            && !node.Deleting
+            && !TerminatingOrDeleted(uid)
+            && !EntityManager.IsQueuedForDeletion(uid)
+            && HasComp<TransformComponent>(uid);
     }
 }

--- a/Content.Server/Imperial/Medieval/Sleepy/Systems/NeedSleepSystem.cs
+++ b/Content.Server/Imperial/Medieval/Sleepy/Systems/NeedSleepSystem.cs
@@ -84,9 +84,7 @@ namespace Content.Server.NeedSleep
                 if (HasComp<SleepingComponent>(uid))
                     continue;
 
-                var emote = _random.Pick(comp.Emotes);
-                if (_random.Prob(comp.SleepLevel / 450f) && comp.SleepLevel > 65 && !HasComp<SleepingComponent>(uid))
-                    _chatSystem.TryEmoteWithChat(uid, emote, ChatTransmitRange.Normal);
+                TryPlaySleepEmote(uid, comp);
 
                 if (comp.SleepLevel > 96.5f)
                 {
@@ -98,6 +96,15 @@ namespace Content.Server.NeedSleep
                 if (comp.SleepLevel >= comp.MaxSleepLevel)
                     EnsureComp<SleepingComponent>(uid);
             }
+        }
+
+        private void TryPlaySleepEmote(EntityUid uid, NeedSleepComponent component)
+        {
+            if (component.Emotes.Count == 0 || component.SleepLevel <= 65f || !_random.Prob(component.SleepLevel / 450f))
+                return;
+
+            var emote = _random.Pick(component.Emotes);
+            _chatSystem.TryEmoteWithChat(uid, emote, ChatTransmitRange.Normal);
         }
     }
 }

--- a/Resources/Prototypes/Body/Species/skeleton.yml
+++ b/Resources/Prototypes/Body/Species/skeleton.yml
@@ -112,6 +112,8 @@
       Female: Skeleton
       Unsexed: Skeleton
   - type: SkeletonAccent
+  - type: NeedSleep
+    enabled: false
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Body/species_base.yml
+++ b/Resources/Prototypes/Body/species_base.yml
@@ -103,6 +103,9 @@
       types:
         Blunt: 5
   - type: SleepEmitSound
+  - type: NeedSleep
+    emotes:
+    - Yawn
   - type: SSDIndicator
   - type: StandingState
   - type: Crawler

--- a/Resources/Prototypes/Imperial/Medieval/dark_elf.yml
+++ b/Resources/Prototypes/Imperial/Medieval/dark_elf.yml
@@ -184,6 +184,9 @@
       180: Dead
   - type: NeedSleep
     sleepLevelPerUpdate: 0.21
+  - type: PointLight
+    netsync: false
+    enabled: false
   - type: LocalLight
     energy: 0.2
     radius: 2.8

--- a/Resources/Prototypes/Imperial/Medieval/medieval.yml
+++ b/Resources/Prototypes/Imperial/Medieval/medieval.yml
@@ -671,6 +671,7 @@
     anchored: true
   - type: Appearance
   - type: Battery
+    netsync: false
     maxCharge: 500000000
     startingCharge: 500000000
   - type: NodeContainer

--- a/Resources/Prototypes/Imperial/Medieval/mobs.yml
+++ b/Resources/Prototypes/Imperial/Medieval/mobs.yml
@@ -3483,9 +3483,8 @@
     baseWalkSpeed: 2
     baseSprintSpeed: 3.2
   - type: PointLight
-    color: red
-    energy: 0.1
-    radius: 1.3
+    netsync: false
+    enabled: false
   - type: NpcFactionMember
     factions:
     - Xeno

--- a/Resources/Prototypes/Imperial/Medieval/nocturn.yml
+++ b/Resources/Prototypes/Imperial/Medieval/nocturn.yml
@@ -294,6 +294,9 @@
     maxManaRaceModifier: 0.95
     regenRaceModifier: 0.95
   - type: Nocturn
+  - type: PointLight
+    netsync: false
+    enabled: false
   - type: LocalLight
     energy: 0.4
     radius: 4.5

--- a/Resources/Prototypes/Imperial/Medieval/ratling.yml
+++ b/Resources/Prototypes/Imperial/Medieval/ratling.yml
@@ -171,6 +171,9 @@
     modifier: 100
   - type: Damageable
     damageModifierSet: Ratling
+  - type: PointLight
+    netsync: false
+    enabled: false
   - type: LocalLight
     energy: 0.2
     radius: 4.2

--- a/Resources/Prototypes/Imperial/Medieval/zveres.yml
+++ b/Resources/Prototypes/Imperial/Medieval/zveres.yml
@@ -200,6 +200,9 @@
   - type: Wagging
   - type: Damageable
     damageModifierSet: Zveres
+  - type: PointLight
+    netsync: false
+    enabled: false
   - type: LocalLight
     energy: 0.2
     radius: 2

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1171,6 +1171,9 @@
   id: PreventAccessLogging # Tagged entities (aghost) will not be added to a device's log. Used by AccessReaderSystem.
 
 - type: Tag
+  id: PreventShipFloorBreakage
+
+- type: Tag
   id: PrisonUniform # CargoBounty: BountyPrisonUniform
 
 - type: Tag


### PR DESCRIPTION
Фикс сломанного NeedSleepSystem

Вернуть удалённое обьявление тега PreventShipFloorBreakage

Защита от краша при попытке переопределить нод у удалённой сущности, касается только неванильных систем RandomPower и трубы мирмексов

Отключение нетсинка у батареи мельничного генератора

Отключение нетсинка у PointLight для существ с ночным зрение. Заставляет хантера больше не светиться в темноте