### PR TITLE
Round extend

### DIFF
--- a/Content.Server/Imperial/Medieval/AutoRoundExtendSystem.cs
+++ b/Content.Server/Imperial/Medieval/AutoRoundExtendSystem.cs
@@ -1,26 +1,35 @@
+using System;
+using System.Collections.Generic;
 using Content.Server.Chat.Managers;
+using Content.Server.Chat.Systems;
 using Content.Server.GameTicking.Events;
+using Content.Server.MagicBarrier.Components;
 using Content.Server.Voting;
 using Content.Server.Voting.Managers;
+using Content.Shared.CCVar;
 using Content.Shared.GameTicking;
-using Robust.Shared.Timing;
+using Robust.Shared.Configuration;
+using Robust.Shared.Random;
 
 namespace Content.Server.GameTicking.Systems;
 
-public sealed partial class AutoRoundEndSystem : EntitySystem
+public sealed partial class AutoRoundExtendSystem : EntitySystem
 {
     [Dependency] private readonly GameTicker _ticker = default!;
     [Dependency] private readonly IVoteManager _voteManager = default!;
     [Dependency] private readonly IChatManager _chatManager = default!;
-    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly ChatSystem _chat = default!;
+    [Dependency] private readonly IRobustRandom _random = default!;
+    [Dependency] private readonly IConfigurationManager _cfg = default!;
 
     private bool _isEnded;
     private bool _leadEventTriggered;
-
     private TimeSpan _targetDuration;
-    private readonly TimeSpan _maxDuration = TimeSpan.FromHours(5);
-    private readonly TimeSpan _voteLeadTime = TimeSpan.FromMinutes(15);
-    private readonly TimeSpan _extensionTime = TimeSpan.FromHours(1);
+
+    private TimeSpan _initialDuration;
+    private TimeSpan _maxDuration;
+    private TimeSpan _voteLeadTime;
+    private TimeSpan _extensionTime;
 
     public override void Initialize()
     {
@@ -28,6 +37,11 @@ public sealed partial class AutoRoundEndSystem : EntitySystem
 
         SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart);
         SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
+
+        _cfg.OnValueChanged(CCVars.AutoRoundInitialDuration, v => _initialDuration = TimeSpan.FromMinutes(v), true);
+        _cfg.OnValueChanged(CCVars.AutoRoundMaxDuration, v => _maxDuration = TimeSpan.FromMinutes(v), true);
+        _cfg.OnValueChanged(CCVars.AutoRoundExtensionTime, v => _extensionTime = TimeSpan.FromMinutes(v), true);
+        _cfg.OnValueChanged(CCVars.AutoRoundVoteLeadTime, v => _voteLeadTime = TimeSpan.FromMinutes(v), true);
     }
 
     private void OnRoundStart(RoundStartingEvent ev)
@@ -44,7 +58,7 @@ public sealed partial class AutoRoundEndSystem : EntitySystem
     {
         _isEnded = false;
         _leadEventTriggered = false;
-        _targetDuration = TimeSpan.FromHours(3);
+        _targetDuration = _initialDuration;
     }
 
     public override void Update(float frameTime)
@@ -82,6 +96,7 @@ public sealed partial class AutoRoundEndSystem : EntitySystem
     {
         var options = new VoteOptions
         {
+            InitiatorText = Loc.GetString("ui-vote-extend-round-initiator"),
             Title = Loc.GetString("ui-vote-extend-round-title"),
             Options =
             {
@@ -116,8 +131,26 @@ public sealed partial class AutoRoundEndSystem : EntitySystem
 
     private void ArmyAttack()
     {
-        _chatManager.DispatchServerAnnouncement(Loc.GetString("auto-round-end-army-attack"));
+        _chat.DispatchGlobalAnnouncement(
+            Loc.GetString("auto-round-end-army-attack"),
+            playSound: true,
+            colorOverride: Color.FromHex("#9403fc"),
+            sender: Loc.GetString("auto-round-end-army-sender"));
 
-        // TODO: Army attack logic
+        var cursespawners = new List<EntityUid>();
+        var query = EntityQueryEnumerator<MagicBarrierNecroSpawnComponent>();
+
+        while (query.MoveNext(out var uid, out var _))
+            cursespawners.Add(uid);
+
+        if (cursespawners.Count == 0)
+            return;
+
+        for (int i = 0; i < 100; i++)
+        {
+            var chosenSpawner = _random.Pick(cursespawners);
+            var cursexform = Transform(chosenSpawner);
+            Spawn("MedievalSpawnNecroSenderPreset", cursexform.Coordinates);
+        }
     }
 }

--- a/Content.Server/Imperial/Medieval/Barrier/MagicBarrierPointSystem.cs
+++ b/Content.Server/Imperial/Medieval/Barrier/MagicBarrierPointSystem.cs
@@ -126,7 +126,7 @@ namespace Content.Server.MagicBarrier
                 _audio.PlayPvs(new SoundPathSpecifier(barrier.EffectSoundOnScrollAdd), target.Value);
                 QueueDel(used);
 
-                _achievement.TryUpdateProgressAndGrant(user, new BarrierRefilledContext(), 
+                _achievement.TryUpdateProgressAndGrant(user, new BarrierRefilledContext(),
                     ach => ach.Conditions.Any(c => c is RefillBarrierCondition));
                 return;
             }
@@ -440,12 +440,12 @@ namespace Content.Server.MagicBarrier
                     //    _chat.DispatchGlobalAnnouncement("Бойтесь, ОНИ идут... Объединение - единственный шанс на спасение.", playSound: true, colorOverride: Color.DeepPink, sender: "Барьер");
                     //}
 
-                    if (comp.Cycle == 180)
-                    {
-                        IsBarrierActive = false;
-                        _chat.DispatchGlobalAnnouncement("Барьер изветшал и рассыпался в пыль.", playSound: true, colorOverride: Color.Red, sender: "Барьер");
-                        _roundEndSystem.EndRound();
-                    }
+                    // if (comp.Cycle == 180)
+                    // {
+                    //     IsBarrierActive = false;
+                    //     _chat.DispatchGlobalAnnouncement("Барьер изветшал и рассыпался в пыль.", playSound: true, colorOverride: Color.Red, sender: "Барьер");
+                    //     _roundEndSystem.EndRound();
+                    // }
                 }
             }
         }

--- a/Content.Server/Imperial/Medieval/VoteContinueRound.cs
+++ b/Content.Server/Imperial/Medieval/VoteContinueRound.cs
@@ -1,0 +1,123 @@
+using Content.Server.Chat.Managers;
+using Content.Server.GameTicking.Events;
+using Content.Server.Voting;
+using Content.Server.Voting.Managers;
+using Content.Shared.GameTicking;
+using Robust.Shared.Timing;
+
+namespace Content.Server.GameTicking.Systems;
+
+public sealed partial class AutoRoundEndSystem : EntitySystem
+{
+    [Dependency] private readonly GameTicker _ticker = default!;
+    [Dependency] private readonly IVoteManager _voteManager = default!;
+    [Dependency] private readonly IChatManager _chatManager = default!;
+    [Dependency] private readonly IGameTiming _timing = default!;
+
+    private bool _isEnded;
+    private bool _leadEventTriggered;
+
+    private TimeSpan _targetDuration;
+    private readonly TimeSpan _maxDuration = TimeSpan.FromHours(5);
+    private readonly TimeSpan _voteLeadTime = TimeSpan.FromMinutes(15);
+    private readonly TimeSpan _extensionTime = TimeSpan.FromHours(1);
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundStartingEvent>(OnRoundStart);
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundCleanup);
+    }
+
+    private void OnRoundStart(RoundStartingEvent ev)
+    {
+        ResetState();
+    }
+
+    private void OnRoundCleanup(RoundRestartCleanupEvent ev)
+    {
+        ResetState();
+    }
+
+    private void ResetState()
+    {
+        _isEnded = false;
+        _leadEventTriggered = false;
+        _targetDuration = TimeSpan.FromHours(3);
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (_isEnded || _ticker.RunLevel != GameRunLevel.InRound)
+            return;
+
+        var currentDuration = _ticker.RoundDuration();
+
+        if (currentDuration >= _targetDuration)
+        {
+            _isEnded = true;
+            _ticker.EndRound(Loc.GetString("auto-round-end-reason"));
+            return;
+        }
+
+        if (!_leadEventTriggered && currentDuration >= _targetDuration - _voteLeadTime)
+        {
+            _leadEventTriggered = true;
+
+            if (_targetDuration < _maxDuration)
+            {
+                StartExtensionVote();
+            }
+            else
+            {
+                ArmyAttack();
+            }
+        }
+    }
+
+    private void StartExtensionVote()
+    {
+        var options = new VoteOptions
+        {
+            Title = Loc.GetString("ui-vote-extend-round-title"),
+            Options =
+            {
+                (Loc.GetString("ui-vote-extend-yes"), "yes"),
+                (Loc.GetString("ui-vote-extend-no"), "no")
+            },
+            Duration = TimeSpan.FromMinutes(3),
+            DisplayVotes = true
+        };
+
+        var vote = _voteManager.CreateVote(options);
+
+        vote.OnFinished += (_, _) =>
+        {
+            var yes = vote.VotesPerOption["yes"];
+            var no = vote.VotesPerOption["no"];
+
+            if (yes > no)
+            {
+                _targetDuration += _extensionTime;
+                _leadEventTriggered = false;
+                _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-extend-success"));
+            }
+            else
+            {
+                _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-extend-fail"));
+            }
+        };
+
+        _chatManager.DispatchServerAnnouncement(Loc.GetString("ui-vote-extend-announcement"));
+    }
+
+    private void ArmyAttack()
+    {
+        _chatManager.DispatchServerAnnouncement(Loc.GetString("auto-round-end-army-attack"));
+
+        // TODO: Army attack logic
+    }
+}

--- a/Content.Shared/CCVar/CCVars.AutoRoundExtendSystem.cs
+++ b/Content.Shared/CCVar/CCVars.AutoRoundExtendSystem.cs
@@ -1,0 +1,30 @@
+using Robust.Shared.Configuration;
+
+namespace Content.Shared.CCVar;
+
+public sealed partial class CCVars
+{
+    /// <summary>
+    /// Начальное время до завершения раунда (в минутах).
+    /// </summary>
+    public static readonly CVarDef<int> AutoRoundInitialDuration =
+        CVarDef.Create("game.auto_round_initial_duration", 180, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Максимальное время раунда со всеми продлениями (в минутах).
+    /// </summary>
+    public static readonly CVarDef<int> AutoRoundMaxDuration =
+        CVarDef.Create("game.auto_round_max_duration", 300, CVar.SERVERONLY);
+
+    /// <summary>
+    /// Время, на которое продлевается раунд при успешном голосовании (в минутах).
+    /// </summary>
+    public static readonly CVarDef<int> AutoRoundExtensionTime =
+        CVarDef.Create("game.auto_round_extension_time", 60, CVar.SERVERONLY);
+
+    /// <summary>
+    /// За сколько минут до конца запускается голосование.
+    /// </summary>
+    public static readonly CVarDef<int> AutoRoundVoteLeadTime =
+        CVarDef.Create("game.auto_round_vote_lead_time", 15, CVar.SERVERONLY);
+}

--- a/Resources/Locale/ru-RU/Imperial/Medieval/autoRoundEndSystem.ftl
+++ b/Resources/Locale/ru-RU/Imperial/Medieval/autoRoundEndSystem.ftl
@@ -1,0 +1,10 @@
+auto-round-end-reason = Время раунда истекло.
+ui-vote-extend-round-initiator = Автоматический продлятор раунда
+ui-vote-extend-round-title = Продлить раунд на 1 час?
+ui-vote-extend-yes = Да
+ui-vote-extend-no = Нет
+ui-vote-extend-success = Голосование за продление раунда завершилось успешно. Раунд продлен на час.
+ui-vote-extend-fail = Голосование за продление раунда провалилось. Раунд завершится через 15 минут.
+ui-vote-extend-announcement = Запущено автоматическое голосование за продление раунда.
+auto-round-end-army-attack = Нет покоя нечестивым. Сотня последователей Морбиуса восстает из-под земли!
+auto-round-end-army-sender = от барьера


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

<!--
    Тип изменения, может быть одним из следующих:
    - feat
    - tweak
    - fix
    - remove

    Ставьте feat, если вы что-то добавили.
    Ставьте tweak, если вы изменили баланс или механику.
    Ставьте fix, если это исправление чего-то.
    Ставьте remove, если вы что-то удалили или ревертнули

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда ставьте feat
-->
Тип: feat
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения: Добавлена система продления раунда. 

<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

Старт раунда (0:00): Устанавливается базовая целевая длительность раунда — 3 часа (настраивается через game.auto_round_initial_duration).

За 15 минут до конца цели (например, в 2:45 и 3:45): Срабатывает триггер проверки (game.auto_round_vote_lead_time).

Если текущая цель меньше максимальной лимитной (5 часов / game.auto_round_max_duration): запускается автоматическое голосование на 3 минуты с вариантами «Да» / «Нет».
При «Да»: целевое время раунда увеличивается на 1 час (game.auto_round_extension_time), триггер сбрасывается.
При «Нет»: раунд не продлевается и завершится через 15 минут.

Достижение лимита в 5 часов (на отметке 4:45): Голосование больше не запускается. Срабатывает ивент атаки армии морбиуса (100 последователей).

Конец раунда: По истечении актуального целевого времени (максимум через 5 часов / 300 минут) раунд завершается принудительно.

Барьер больше не завершает раунд на 180 цикле

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*
