### PR TITLE
Add Inkeeper Assistant and Guard Roles

### DIFF
--- a/Resources/Locale/en-US/Imperial/Medieval/Roles/innkeeper_misc.ftl
+++ b/Resources/Locale/en-US/Imperial/Medieval/Roles/innkeeper_misc.ftl
@@ -1,0 +1,5 @@
+job-name-innkeeper-assistant = Innkeeper Assistant of the southern lands
+job-description-innkeeper-assistant = Help the innkeeper serve guests, prepare food, clean, and maintain the innkeeper.
+
+job-name-innkeeper-guard = Innkeeper Guard of the southern lands
+job-description-innkeeper-guard = Keep order in the innkeeper, protect its staff and guests, and stop fights.

--- a/Resources/Locale/ru-RU/Imperial/Medieval/Roles/innkeeper_misc.ftl
+++ b/Resources/Locale/ru-RU/Imperial/Medieval/Roles/innkeeper_misc.ftl
@@ -1,0 +1,5 @@
+job-name-innkeeper-assistant = Помощник таверны
+job-description-innkeeper-assistant = Помогайте трактирщику обслуживать посетителей, готовить, убирать и вести хозяйство таверны.
+
+job-name-innkeeper-guard = Охранник таверны
+job-description-innkeeper-guard = Следите за порядком в таверне, защищайте работников и посетителей и пресекайте драки.

--- a/Resources/Prototypes/Imperial/Medieval/custom_departments.yml
+++ b/Resources/Prototypes/Imperial/Medieval/custom_departments.yml
@@ -10,6 +10,8 @@
   - MedievalBum
   - MedievalInnkeeper
   - MedievalInnkeeperN
+  - MedievalInnkeeperAssistant
+  - MedievalInnkeeperGuard
   - MedievalChaplain
   - MedievalWanderMag
   - MedievalArchivist

--- a/Resources/Prototypes/Imperial/Medieval/jobs.yml
+++ b/Resources/Prototypes/Imperial/Medieval/jobs.yml
@@ -1762,6 +1762,110 @@
     proto: InnkeeperTimer4hours
   equipment:
     outerClothing: MedievalClothingHeadCloth
+    
+# MEDIEVAL TAVERN ASSISTANT
+
+- type: startingGear
+  id: MedievalInnkeeperAssistantGear
+  equipment:
+    pocket1: MedievalRevent25
+    jumpsuit: MedievalClothingUniformJumpsuitShitCloth12
+    id: MedievalKeyTavern
+
+- type: playTimeTracker
+  id: JobMedievalInnkeeperAssistant
+
+- type: jobIcon
+  parent: JobIcon
+  id: JobIconMedievalInnkeeperAssistant
+  icon:
+    sprite: /Textures/Imperial/Medieval/Misc/job_icons.rsi
+    state: innkeeper
+  jobName: job-name-innkeeper-assistant
+
+- type: job
+  id: MedievalInnkeeperAssistant
+  name: job-name-innkeeper-assistant
+  description: job-description-innkeeper-assistant
+  playTimeTracker: JobMedievalInnkeeperAssistant
+  startingGear: MedievalInnkeeperAssistantGear
+  icon: "JobIconMedievalInnkeeperAssistant"
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: WarningOnAttach
+      message: medieval-warning-base
+    - type: MedievalJobSpawn
+      spawnType: LegionTrader
+    - type: GiveItemObjective
+    - type: MoneyCollector
+      objectivePrototype: MedievalGetMoneyObjective300500
+    - type: Farmer
+
+- type: roleLoadout
+  id: JobMedievalInnkeeperAssistant
+  groups:
+  - InnkeeperHead
+  - MedievalBackpack
+  - MedievalShoes
+  - MedievalBelt
+  - InnkeeperFartuk
+  - MedievalTrinkets
+  - MedievalGloves
+
+# MEDIEVAL INNKEEPER GUARD
+
+- type: startingGear
+  id: MedievalInnkeeperGuardGear
+  equipment:
+    pocket1: MedievalRevent25
+    jumpsuit: MedievalClothingUniformJumpsuitShitCloth11
+    head: MedievalClothingHeadHelmetNormandFree
+    outerClothing: MedievalClothingOuterArmorGambeson
+    neck: MedievalClothingNeckCloakViking
+    id: MedievalKeyTavern
+  inhand:
+  - MedievalFalshionT3
+
+- type: playTimeTracker
+  id: JobMedievalInnkeeperGuard
+
+- type: jobIcon
+  parent: JobIcon
+  id: JobIconMedievalInnkeeperGuard
+  icon:
+    sprite: /Textures/Imperial/Medieval/Misc/job_icons.rsi
+    state: villager_def
+  jobName: job-name-innkeeper-guard
+
+- type: job
+  id: MedievalInnkeeperGuard
+  name: job-name-innkeeper-guard
+  description: job-description-innkeeper-guard
+  playTimeTracker: JobMedievalInnkeeperGuard
+  startingGear: MedievalInnkeeperGuardGear
+  icon: "JobIconMedievalInnkeeperGuard"
+  special:
+  - !type:AddComponentSpecial
+    components:
+    - type: WarningOnAttach
+      message: medieval-warning-base
+    - type: MedievalJobSpawn
+      spawnType: LegionTrader
+    - type: GiveItemObjective
+    - type: MoneyCollector
+      objectivePrototype: MedievalGetMoneyObjective300500
+
+- type: roleLoadout
+  id: JobMedievalInnkeeperGuard
+  groups:
+  - MedievalBackpack
+  - MedievalBelt
+  - MedievalTrinkets
+  - MedievalGloves
+  - MedievalShoes
+  - MedievalRepair
+
 
 # MEDIEVAL INNKEEPERN
 

--- a/Resources/Prototypes/Imperial/Medieval/map.yml
+++ b/Resources/Prototypes/Imperial/Medieval/map.yml
@@ -12,13 +12,15 @@
           mapNameTemplate: "Medieval"
         - type: StationJobs
           availableJobs:
-            # Free people (31 total)
+            # Free people (35 total)
             MedievalTraveller: [ -1, -1 ]
             MedievalAvanturist: [ 7, 7 ]
             MedievalBard: [ 3, 3 ]
             MedievalBum: [ 10, 10 ]
             MedievalInnkeeper: [ 1, 1 ]
             MedievalInnkeeperN: [ 1, 1 ]
+            MedievalInnkeeperAssistant: [ 3, 3 ]
+            MedievalInnkeeperGuard: [ 1, 1 ]
             MedievalChaplain: [ 7, 7 ]
             MedievalWanderMag: [ 4, 4 ]
             # Legion (29 total)
@@ -96,13 +98,15 @@
           mapNameTemplate: "Medieval"
         - type: StationJobs
           availableJobs:
-            # Free people (26 total)
+            # Free people (30 total)
             MedievalTraveller: [ -1, -1 ]
             MedievalAvanturist: [ 5, 5 ]
             MedievalBard: [ 3, 3 ]
             MedievalBum: [ 10, 10 ]
             MedievalInnkeeper: [ 1, 1 ]
             MedievalInnkeeperN: [ 1, 1 ]
+            MedievalInnkeeperAssistant: [ 3, 3 ]
+            MedievalInnkeeperGuard: [ 1, 1 ]
             MedievalChaplain: [ 5, 5 ]
             MedievalWanderMag: [ 3, 3 ]
             # Legion (22 total)
@@ -178,13 +182,15 @@
           mapNameTemplate: "Medieval"
         - type: StationJobs
           availableJobs:
-            # Free people (20 total)
+            # Free people (23 total)
             MedievalTraveller: [ -1, -1 ]
             MedievalAvanturist: [ 3, 3 ]
             MedievalBard: [ 2, 2 ]
             MedievalBum: [ 8, 8 ]
             MedievalInnkeeper: [ 1, 1 ]
             MedievalInnkeeperN: [ 1, 1 ]
+            MedievalInnkeeperAssistant: [ 2, 2 ]
+            MedievalInnkeeperGuard: [ 1, 1 ]
             MedievalChaplain: [ 3, 3 ]
             MedievalWanderMag: [ 2, 2 ]
             # Legion (15 total)
@@ -259,13 +265,15 @@
           mapNameTemplate: "Medieval"
         - type: StationJobs
           availableJobs:
-            # Free people (14 total)
+            # Free people (17 total)
             MedievalTraveller: [ -1, -1 ]
             MedievalAvanturist: [ 1, 1 ]
             MedievalBard: [ 2, 2 ]
             MedievalBum: [ 6, 6 ]
             MedievalInnkeeper: [ 1, 1 ]
             MedievalInnkeeperN: [ 1, 1 ]
+            MedievalInnkeeperAssistant: [ 2, 2 ]
+            MedievalInnkeeperGuard: [ 1, 1 ]
             MedievalChaplain: [ 2, 2 ]
             MedievalWanderMag: [ 1, 1 ]
             # Legion (11 total)
@@ -335,13 +343,15 @@
           mapNameTemplate: "Medieval"
         - type: StationJobs
           availableJobs:
-            # Free people (8 total)
+            # Free people (11 total)
             MedievalTraveller: [ -1, -1 ]
             #MedievalAvanturist: [ 1, 1 ]
             MedievalBard: [ 1, 1 ]
             MedievalBum: [ 3, 3 ]
             MedievalInnkeeper: [ 1, 1 ]
             MedievalInnkeeperN: [ 1, 1 ]
+            MedievalInnkeeperAssistant: [ 2, 2 ]
+            MedievalInnkeeperGuard: [ 1, 1 ]
             MedievalChaplain: [ 1, 1 ]
             MedievalWanderMag: [ 1, 1 ]
             # Legion (8 total)


### PR DESCRIPTION
<img width="510" height="95" alt="larp1" src="https://github.com/user-attachments/assets/0f504094-e7e8-4aaf-b043-894f55968c82" />
<img width="767" height="608" alt="larp2" src="https://github.com/user-attachments/assets/5a973caa-7127-43b9-9602-99f3356a68cb" />


## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

<!--
    Тип изменения, может быть одним из следующих:
    - feat
    - tweak
    - fix
    - remove

    Ставьте feat, если вы что-то добавили.
    Ставьте tweak, если вы изменили баланс или механику.
    Ставьте fix, если это исправление чего-то.
    Ставьте remove, если вы что-то удалили или ревертнули

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда ставьте feat
-->
Тип: feat
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения: Added 2 slots for Innkeeper Assistants, 1 for guard; both southern.

<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

- Assistant is basically a duplicate loadout of the Innkeeper.
- Guard spawns with an iron long sword, normand iron helm, and fur cloak.
- Both have tavern keys.
- **NOTE:** map.yml will have to be changed for the new map.

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*
