### PR TITLE
Фикс 7

### DIFF
--- a/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegrityComponent.cs
+++ b/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegrityComponent.cs
@@ -1,9 +1,11 @@
 using Content.Shared.Damage.Prototypes;
+using Content.Shared.Explosion;
 using Content.Shared.Imperial.Medieval.SmithingSystem.Behaviours;
 using Robust.Shared.Audio;
 using Robust.Shared.GameStates;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Dictionary;
 
 namespace Content.Shared.Imperial.Medieval.ArmorIntegrity;
 
@@ -32,6 +34,12 @@ public sealed partial class MedievalArmorIntegrityComponent : Component
         { "Holy", new MedievalArmorResistance() },
         { "ParryAble", new MedievalArmorResistance() },
     };
+
+    [DataField, AutoNetworkedField]
+    public MedievalArmorExplosionResistance UnbrokenExplosionResistance = new();
+
+    [DataField, AutoNetworkedField]
+    public MedievalArmorExplosionResistance BrokenExplosionResistance = new();
 
     [DataField, AutoNetworkedField]
     public Dictionary<ProtoId<DamageTypePrototype>, float> BreakageMultipliers = new()
@@ -92,4 +100,20 @@ public sealed partial class MedievalArmorResistance
 
     [DataField]
     public float FlatReduction;
+}
+
+[DataDefinition, Serializable, NetSerializable]
+public sealed partial class MedievalArmorExplosionResistance
+{
+    [DataField]
+    public float DamageCoefficient = 1f;
+
+    [DataField]
+    public bool Worn = true;
+
+    [DataField]
+    public LocId Examine = "explosion-resistance-coefficient-value";
+
+    [DataField("modifiers", customTypeSerializer: typeof(PrototypeIdDictionarySerializer<float, ExplosionPrototype>))]
+    public Dictionary<string, float> Modifiers = new();
 }

--- a/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
+++ b/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Examine;
 using Content.Shared.Explosion;
+using Content.Shared.Explosion.Components;
 using Content.Shared.Ghost;
 using Content.Shared.Imperial.Medieval.Skills;
 using Content.Shared.Imperial.Medieval.SmithingSystem.Behaviours;
@@ -31,6 +32,10 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
 
         SubscribeLocalEvent<MedievalArmorIntegrityComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<MedievalArmorIntegrityComponent, ExaminedEvent>(OnArmorExamined);
+        SubscribeLocalEvent<MedievalArmorIntegrityComponent, ArmorExamineEvent>(OnArmorExamine);
+        SubscribeLocalEvent<MedievalArmorIntegrityComponent, GetExplosionResistanceEvent>(OnGetExplosionResistance);
+        SubscribeLocalEvent<MedievalArmorIntegrityComponent, InventoryRelayedEvent<GetExplosionResistanceEvent>>(
+            OnRelayedExplosionResistance);
         SubscribeLocalEvent<DamageableComponent, DamageModifyEvent>(OnDamageModify,
             after: [typeof(InventorySystem)]);
         SubscribeLocalEvent<DamageableComponent, BeforeExplodeEvent>(OnBeforeExplode);
@@ -79,9 +84,48 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
         if (TryComp<ArmorComponent>(ent, out var armor) && ent.Comp.UnbrokenResistances.Count == 0)
             CopyArmorResistances(armor.Modifiers, ent.Comp.UnbrokenResistances);
 
+        if (HasComp<ExplosionResistanceComponent>(ent))
+        {
+            if (IsDefaultExplosionResistance(ent.Comp.UnbrokenExplosionResistance) &&
+                IsDefaultExplosionResistance(ent.Comp.BrokenExplosionResistance))
+            {
+                ent.Comp.UnbrokenExplosionResistance = CopyExplosionResistance(ent);
+            }
+
+            RemCompDeferred<ExplosionResistanceComponent>(ent);
+        }
+
         SetContainerArmorHP(ent, ent.Comp.ContainerArmorHP);
         SetArmorResistances(ent, ent.Comp.IsBroken ? ent.Comp.BrokenResistances : ent.Comp.UnbrokenResistances);
         Dirty(ent);
+    }
+
+    private void OnArmorExamine(Entity<MedievalArmorIntegrityComponent> ent, ref ArmorExamineEvent args)
+    {
+        var resistance = GetExplosionResistance(ent.Comp);
+        var value = MathF.Round((1f - resistance.DamageCoefficient) * 100, 1);
+
+        if (value == 0)
+            return;
+
+        args.Msg.PushNewline();
+        args.Msg.AddMarkupOrThrow(Loc.GetString(resistance.Examine, ("value", value)));
+    }
+
+    private void OnGetExplosionResistance(
+        Entity<MedievalArmorIntegrityComponent> ent,
+        ref GetExplosionResistanceEvent args)
+    {
+        ApplyExplosionResistance(GetExplosionResistance(ent.Comp), ref args);
+    }
+
+    private void OnRelayedExplosionResistance(
+        Entity<MedievalArmorIntegrityComponent> ent,
+        ref InventoryRelayedEvent<GetExplosionResistanceEvent> args)
+    {
+        var resistance = GetExplosionResistance(ent.Comp);
+        if (resistance.Worn)
+            ApplyExplosionResistance(resistance, ref args.Args);
     }
 
     private void OnArmorExamined(Entity<MedievalArmorIntegrityComponent> ent, ref ExaminedEvent args)
@@ -340,6 +384,81 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
 
             resistance.FlatReduction = flatReduction;
         }
+    }
+
+    private MedievalArmorExplosionResistance CopyExplosionResistance(EntityUid entity)
+    {
+        var resistance = new MedievalArmorExplosionResistance();
+        var baseResistance = GetExplosionDamageCoefficient(entity, string.Empty);
+        resistance.DamageCoefficient = baseResistance;
+
+        string? wornProbe = null;
+        var wornProbeCoefficient = baseResistance;
+        if (baseResistance != 1f)
+            wornProbe = string.Empty;
+
+        if (baseResistance != 0f)
+        {
+            foreach (var explosion in _prototype.EnumeratePrototypes<ExplosionPrototype>())
+            {
+                var coefficient = GetExplosionDamageCoefficient(entity, explosion.ID);
+                var modifier = coefficient / baseResistance;
+                if (modifier != 1f)
+                    resistance.Modifiers[explosion.ID] = modifier;
+
+                if (wornProbe == null && coefficient != 1f)
+                {
+                    wornProbe = explosion.ID;
+                    wornProbeCoefficient = coefficient;
+                }
+            }
+        }
+
+        if (wornProbe != null)
+            resistance.Worn = GetRelayedExplosionDamageCoefficient(entity, wornProbe) == wornProbeCoefficient;
+
+        return resistance;
+    }
+
+    private float GetExplosionDamageCoefficient(EntityUid entity, string explosionPrototype)
+    {
+        var ev = new GetExplosionResistanceEvent(explosionPrototype);
+        RaiseLocalEvent(entity, ref ev);
+        return ev.DamageCoefficient;
+    }
+
+    private float GetRelayedExplosionDamageCoefficient(EntityUid entity, string explosionPrototype)
+    {
+        var ev = new InventoryRelayedEvent<GetExplosionResistanceEvent>(
+            new GetExplosionResistanceEvent(explosionPrototype),
+            entity);
+        RaiseLocalEvent(entity, ev);
+        return ev.Args.DamageCoefficient;
+    }
+
+    private static bool IsDefaultExplosionResistance(MedievalArmorExplosionResistance resistance)
+    {
+        return resistance.DamageCoefficient == 1f &&
+               resistance.Worn &&
+               resistance.Examine == "explosion-resistance-coefficient-value" &&
+               resistance.Modifiers.Count == 0;
+    }
+
+    private static MedievalArmorExplosionResistance GetExplosionResistance(
+        MedievalArmorIntegrityComponent component)
+    {
+        return component.IsBroken
+            ? component.BrokenExplosionResistance
+            : component.UnbrokenExplosionResistance;
+    }
+
+    private static void ApplyExplosionResistance(
+        MedievalArmorExplosionResistance resistance,
+        ref GetExplosionResistanceEvent args)
+    {
+        args.DamageCoefficient *= resistance.DamageCoefficient;
+        if (resistance.Modifiers.TryGetValue(args.ExplosionPrototype, out var modifier))
+            args.DamageCoefficient *= modifier;
     }
 
     private static DamageModifierSet CreateModifierSet(

--- a/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
+++ b/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Examine;
 using Content.Shared.Explosion;
+using Content.Shared.Ghost;
 using Content.Shared.Imperial.Medieval.Skills;
 using Content.Shared.Imperial.Medieval.SmithingSystem.Behaviours;
 using Content.Shared.Inventory;
@@ -101,7 +102,9 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
 
     private void OnCharacterExamined(Entity<InventoryComponent> ent, ref ExaminedEvent args)
     {
-        var intelligence = _skills.GetSkillLevel(args.Examiner, SharedSkillsSystem.IntelligenceId);
+        var intelligence = HasComp<GhostComponent>(args.Examiner)
+            ? 20
+            : _skills.GetSkillLevel(args.Examiner, SharedSkillsSystem.IntelligenceId);
         if (intelligence <= 8)
             return;
 

--- a/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
+++ b/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Armor;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Prototypes;
 using Content.Shared.Examine;
+using Content.Shared.Explosion;
 using Content.Shared.Imperial.Medieval.Skills;
 using Content.Shared.Imperial.Medieval.SmithingSystem.Behaviours;
 using Content.Shared.Inventory;
@@ -17,6 +18,7 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
+    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedSkillsSystem _skills = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -30,6 +32,7 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
         SubscribeLocalEvent<MedievalArmorIntegrityComponent, ExaminedEvent>(OnArmorExamined);
         SubscribeLocalEvent<DamageableComponent, DamageModifyEvent>(OnDamageModify,
             after: [typeof(InventorySystem)]);
+        SubscribeLocalEvent<DamageableComponent, BeforeExplodeEvent>(OnBeforeExplode);
         SubscribeLocalEvent<InventoryComponent, ExaminedEvent>(OnCharacterExamined);
     }
 
@@ -40,13 +43,31 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
             !TryComp<InventoryComponent>(ent, out var inventory))
             return;
 
+        DamageEquippedArmor(ent.Owner, inventory, args.OriginalDamage);
+    }
+
+    private void OnBeforeExplode(Entity<DamageableComponent> ent, ref BeforeExplodeEvent args)
+    {
+        if (!_net.IsServer ||
+            !TryComp<InventoryComponent>(ent, out var inventory))
+            return;
+
+        var damage = args.Damage * _damageable.UniversalExplosionDamageModifier;
+        if (!damage.AnyPositive())
+            return;
+
+        DamageEquippedArmor(ent.Owner, inventory, damage);
+    }
+
+    private void DamageEquippedArmor(EntityUid wearer, InventoryComponent inventory, DamageSpecifier damage)
+    {
         var equippedArmor = GetEquippedArmor(inventory, includeBroken: false);
         if (equippedArmor.Count == 0)
             return;
 
-        var dividedDamage = args.OriginalDamage / equippedArmor.Count;
+        var dividedDamage = damage / equippedArmor.Count;
         foreach (var armor in equippedArmor)
-            DamageArmor(armor, dividedDamage, ent.Owner);
+            DamageArmor(armor, dividedDamage, wearer);
     }
 
     private void OnComponentInit(Entity<MedievalArmorIntegrityComponent> ent, ref ComponentInit args)

--- a/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
+++ b/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
@@ -18,8 +18,8 @@ namespace Content.Shared.Imperial.Medieval.ArmorIntegrity;
 public sealed class MedievalArmorIntegritySystem : EntitySystem
 {
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
     [Dependency] private readonly SharedSkillsSystem _skills = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
@@ -53,7 +53,7 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
             !TryComp<InventoryComponent>(ent, out var inventory))
             return;
 
-        var damage = args.Damage * _damageable.UniversalExplosionDamageModifier;
+        var damage = _prototype.Index<ExplosionPrototype>(args.Id).DamagePerIntensity * args.Intensity;
         if (!damage.AnyPositive())
             return;
 

--- a/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
+++ b/Content.Shared/Imperial/Medieval/ArmorIntegrity/MedievalArmorIntegritySystem.cs
@@ -86,11 +86,8 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
 
         if (HasComp<ExplosionResistanceComponent>(ent))
         {
-            if (IsDefaultExplosionResistance(ent.Comp.UnbrokenExplosionResistance) &&
-                IsDefaultExplosionResistance(ent.Comp.BrokenExplosionResistance))
-            {
+            if (IsDefaultExplosionResistance(ent.Comp.UnbrokenExplosionResistance))
                 ent.Comp.UnbrokenExplosionResistance = CopyExplosionResistance(ent);
-            }
 
             RemCompDeferred<ExplosionResistanceComponent>(ent);
         }
@@ -439,8 +436,6 @@ public sealed class MedievalArmorIntegritySystem : EntitySystem
     private static bool IsDefaultExplosionResistance(MedievalArmorExplosionResistance resistance)
     {
         return resistance.DamageCoefficient == 1f &&
-               resistance.Worn &&
-               resistance.Examine == "explosion-resistance-coefficient-value" &&
                resistance.Modifiers.Count == 0;
     }
 


### PR DESCRIPTION
Госты видят целостность брони в процентах

Взрывы изнашивают броню

При инициализации брони с компонентом medieval armor integrity, ванильный компонент защиты взрывов удаляется, а его работу начинает выполнять система целостности брони. Изначальный модификатор защиты от взрывов берётся из ванильного компонента, если только он не задан прототипером напрямую в компоненте armor integrity

Иными словами, иных действий от прототиперов не требуется. При поломке брони, она будет терять резист от взрывов