### PR TITLE
Special Damage System

### DIFF
--- a/Content.Server/Imperial/Medieval/SpecialDamage/MedievalSpecialDamageSystem.cs
+++ b/Content.Server/Imperial/Medieval/SpecialDamage/MedievalSpecialDamageSystem.cs
@@ -1,0 +1,30 @@
+using Content.Shared.Damage;
+using Content.Shared.Imperial.Medieval.SpecialDamage;
+using Content.Shared.Weapons.Melee.Events;
+
+namespace Content.Server.Imperial.Medieval.SpecialDamage;
+
+public sealed class MedievalSpecialDamageSystem : EntitySystem
+{
+    [Dependency] private readonly DamageableSystem _damageable = default!;
+
+    public override void Initialize()
+    {
+        SubscribeLocalEvent<MedievalSpecialDamageDealerComponent, MeleeHitEvent>(OnMeleeHit);
+    }
+
+    private void OnMeleeHit(EntityUid uid, MedievalSpecialDamageDealerComponent component, MeleeHitEvent args)
+    {
+        if (!args.IsHit)
+            return;
+
+        foreach (var target in args.HitEntities)
+        {
+            if (!TryComp<MedievalSpecialDamageReceiverComponent>(target, out var receiver) ||
+                receiver.TargetType != component.TargetType)
+                continue;
+
+            _damageable.TryChangeDamage(target, component.Damage, origin: args.User);
+        }
+    }
+}

--- a/Content.Shared/Imperial/Medieval/SpecialDamage/MedievalSpecialDamageComponents.cs
+++ b/Content.Shared/Imperial/Medieval/SpecialDamage/MedievalSpecialDamageComponents.cs
@@ -1,0 +1,20 @@
+using Content.Shared.Damage;
+
+namespace Content.Shared.Imperial.Medieval.SpecialDamage;
+
+[RegisterComponent]
+public sealed partial class MedievalSpecialDamageDealerComponent : Component
+{
+    [DataField]
+    public DamageSpecifier Damage = new();
+
+    [DataField]
+    public string TargetType = string.Empty;
+}
+
+[RegisterComponent]
+public sealed partial class MedievalSpecialDamageReceiverComponent : Component
+{
+    [DataField]
+    public string TargetType = string.Empty;
+}


### PR DESCRIPTION
Type: feat
Changes: Added special damage system that allows weapons to deal special damage to designated targets.

## Technical Details

* Added "MedievalSpecialDamageDealerComponent", which stores special damage and the target type for an entity.
* Added "MedievalSpecialDamageReceiverComponent", which defines the target type an entity can receive the special damage from.
* Added "MedievalSpecialDamageSystem", which looks for "MeleeHitEvent" and applies the configured damage when the dealer's "TargetType" matches the receiver's "TargetType".

## How to Use
Add "MedievalSpecialDamageDealerComponent" to a weapon and set the "Damage" and "TargetType".
Add "MedievalSpecialDamageReceiverComponent" to the target and set its "TargetType" to the same as the weapon.

## Notes
- This only works for "weapon strikes", meaning only melee weapons.
- Empty strings will match.
- I have not gotten the time to test this yet and my coding is subpar, so beware.