### PR TITLE
balance.

### DIFF
--- a/Content.Shared/Imperial/Medieval/WeaponSkillSystem/WeaponSkills.cs
+++ b/Content.Shared/Imperial/Medieval/WeaponSkillSystem/WeaponSkills.cs
@@ -42,7 +42,7 @@ public sealed partial class OneHandedBluntSkillComponent : Component
 public sealed partial class OneHandedBluntLightSkillComponent : Component
 {
     [DataField("damageMult")] public float DamageMult = 1.10f;
-    [DataField("staminaDamage")] public float StaminaDamage = 1f;
+    [DataField("staminaDamage")] public float StaminaDamage = 0.5f;
     [DataField("bypassType")] public string BypassType = "Blunt";
     [DataField("bypassAmount")] public FixedPoint2 BypassAmount = 0.5f;
 }
@@ -80,9 +80,9 @@ public sealed partial class TwoHandedSkillComponent : Component
 [RegisterComponent, NetworkedComponent]
 public sealed partial class CrossbowSkillComponent : Component
 {
-    [DataField("staminaOnHit")] public float StaminaOnHit = 9f;
+    [DataField("staminaOnHit")] public float StaminaOnHit = 11f;
     [DataField("bypassType")] public string BypassType = "Piercing";
-    [DataField("bypassAmount")] public FixedPoint2 BypassAmount = 4f;
+    [DataField("bypassAmount")] public FixedPoint2 BypassAmount = 5f;
 }
 
 [RegisterComponent, NetworkedComponent]

--- a/Resources/Prototypes/Imperial/Medieval/Bosses/MiniBosses/dragon/mob.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Bosses/MiniBosses/dragon/mob.yml
@@ -103,10 +103,12 @@
         path: /Audio/Weapons/Xeno/alien_claw_flesh3.ogg
       damage:
         groups:
-          Brute: 48
+          Brute: 80
+          Airloss: 10
         types:
           Structural: 600
           ParryAble: 0.25
+          Bloodloss: 10
       range: 2.5
       attackRate: 0.5
     - type: StaminaDamageOnHit

--- a/Resources/Prototypes/Imperial/Medieval/Bosses/MiniBosses/dragon/mob.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Bosses/MiniBosses/dragon/mob.yml
@@ -169,14 +169,14 @@
         state: alive
       sprite: Imperial/Medieval/Mobs/Bosses/Dragons/icedragon.rsi
     - type: HitscanBatteryAmmoProvider
-      proto: MedievalProjectileWaterSphereBeginner
+      proto: MedievalProjectileWaterSphereIceDragon
       fireCost: 1
     - type: Battery
       maxCharge: 10000
       startingCharge: 10000
     - type: Gun
       projectileSpeed: 8
-      fireRate: 1.3
+      fireRate: 0.25
       useKey: false
       selectedMode: SemiAuto
       availableModes:

--- a/Resources/Prototypes/Imperial/Medieval/Bosses/MiniBosses/dragon/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Bosses/MiniBosses/dragon/projectiles.yml
@@ -136,3 +136,18 @@
   impactFlash:
     sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
     state: impact_blue
+
+- type: hitscan
+  id: MedievalProjectileWaterSphereIceDragon
+  damage:
+    types:
+      Cold: 25
+  muzzleFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: muzzle_blue
+  travelFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: beam_blue
+  impactFlash:
+    sprite: Objects/Weapons/Guns/Projectiles/projectiles.rsi
+    state: impact_blue

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/FireWall/actions.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/FireWall/actions.yml
@@ -41,12 +41,12 @@
       spawnedEntityPrototype: MedievalFireWallBeginner
       spawnType: SpawnOnMousePosition
       spellCastDoAfter:
-        delay: 2.5
+        delay: 2.7
         breakOnDropItem: false
         breakOnWeightlessMove: false
         breakOnMove: false
         needHand: true
-        speedModifier: 0.3
+        speedModifier: 0.75
       speechPoints:
         0:
           speech: medieval-spell-speach-fire-wall
@@ -104,12 +104,12 @@
       spawnedEntityPrototype: MedievalFireWallMiddle
       spawnType: SpawnOnMousePosition
       spellCastDoAfter:
-        delay: 3
+        delay: 2.5
         breakOnDropItem: false
         breakOnWeightlessMove: false
         breakOnMove: false
         needHand: true
-        speedModifier: 0.3
+        speedModifier: 0.75
       speechPoints:
         0:
           speech: medieval-spell-speach-fire-wall
@@ -161,12 +161,12 @@
       spawnedEntityPrototype: MedievalFireWallSenior
       spawnType: SpawnOnMousePosition
       spellCastDoAfter:
-        delay: 3.5
+        delay: 2.3
         breakOnDropItem: false
         breakOnWeightlessMove: false
         breakOnMove: false
         needHand: true
-        speedModifier: 0.3
+        speedModifier: 0.75
       speechPoints:
         0:
           speech: medieval-spell-speach-fire-wall

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/FireWall/effect.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Fire/FireWall/effect.yml
@@ -53,4 +53,4 @@
     energy: 3
     color: "#ff9c24"
   - type: TimedDespawn
-    lifetime: 3.5
+    lifetime: 4

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Light/Sunstrike/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Light/Sunstrike/projectiles.yml
@@ -70,7 +70,7 @@
   - type: DamageContacts
     damage:
       types:
-        Heat: 10
+        Heat: 18
   - type: IgniteOnCollide
     fixtureId: fix1
     fireStacks: 2

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/MultiСurrency/Sleep/store.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/MultiСurrency/Sleep/store.yml
@@ -12,7 +12,7 @@
     sprite: Imperial/Medieval/Magic/MultiCurrency/Sleep/icons.rsi
     state: middle
   cost:
-    MagicMedievalVodka: 70
+    MagicMedievalVodka: 80
   categories:
   - MedievalVodkaSpells
   conditions:

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/Smoke/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/Smoke/projectiles.yml
@@ -41,4 +41,4 @@
     solution:
       reagents:
       - ReagentId: TearGas
-        Quantity: 50
+        Quantity: 20

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
@@ -1151,16 +1151,16 @@
 - type: damageModifierSet
   id: MyrmexArmorOff
   coefficients:
-    Blunt: 0.85
-    Slash: 0.85
-    Piercing: 0.85
-    Heat: 0.85
+    Blunt: 0.9
+    Slash: 0.9
+    Piercing: 0.9
+    Heat: 0.9
 
 - type: damageModifierSet
   id: MyrmexArmorOn
   coefficients:
-    Blunt: 0.55
-    Slash: 0.55
-    Piercing: 0.55
-    Heat: 0.55
+    Blunt: 0.35
+    Slash: 0.35
+    Piercing: 0.35
+    Heat: 0.35
 

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
@@ -315,7 +315,7 @@
         damage:
           types:
             Heat: 1
-            Poison: 3.5
+            Poison: 2
 
 - type: entity
   id: MedievalMyrmexTrapBase
@@ -367,7 +367,7 @@
     lastVisibility: 0.33
   - type: SmokeOnTrigger
     duration: 25 # Я ЕБНУТЫЙ, БЕГИТЕ
-    spreadAmount: 30
+    spreadAmount: 15
     solution:
       reagents:
       - ReagentId: MedievalMyrmexPoison
@@ -690,8 +690,7 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 5
-        Airloss: 2
+        Brute: 7
       types:
         ParryAble: 1
   - type: Gun
@@ -760,11 +759,9 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 14
-        Airloss: 3
+        Brute: 21
       types:
         ParryAble: 1
-        Bloodloss: 4
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -824,11 +821,9 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 10
-        Airloss: 2
+        Brute: 14
       types:
         ParryAble: 1
-        Bloodloss: 2
   - type: MobThresholds
     thresholds:
       0: Alive
@@ -976,11 +971,11 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 20
-        Airloss: 3
+        Brute: 25
+        Airloss: 1
       types:
         ParryAble: 1
-        Bloodloss: 5
+        Bloodloss: 2
         Structural: 155
   - type: MobThresholds
     thresholds:
@@ -1164,8 +1159,8 @@
 - type: damageModifierSet
   id: MyrmexArmorOn
   coefficients:
-    Blunt: 0.35
-    Slash: 0.35
-    Piercing: 0.35
-    Heat: 0.35
+    Blunt: 0.60
+    Slash: 0.60
+    Piercing: 0.60
+    Heat: 0.60
 

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
@@ -367,7 +367,7 @@
     lastVisibility: 0.33
   - type: SmokeOnTrigger
     duration: 25 # Я ЕБНУТЫЙ, БЕГИТЕ
-    spreadAmount: 15
+    spreadAmount: 30
     solution:
       reagents:
       - ReagentId: MedievalMyrmexPoison
@@ -677,7 +677,7 @@
     rechargeSound:
       path: /Audio/Imperial/Medieval/ant_acidrecharge.ogg
   - type: BasicEntityAmmoProvider
-    proto: MedievalMyrmexBulletAcid
+    proto: BulletAcid
     capacity: 1
     count: 1
   - type: MeleeWeapon
@@ -704,7 +704,7 @@
     thresholds:
       0: Alive
       100: Critical
-      120: Dead
+      170: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.4
     baseSprintSpeed: 2.2
@@ -759,14 +759,14 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 30
+        Brute: 22
       types:
         ParryAble: 1
   - type: MobThresholds
     thresholds:
       0: Alive
-      510: Critical # curse of 220. no. 310. no. 510.
-      650: Dead
+      310: Critical # curse of 220. no. 310.
+      450: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 1.8
@@ -821,15 +821,14 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 35
-        Airloss: 1
+        Brute: 14
       types:
         ParryAble: 1
   - type: MobThresholds
     thresholds:
       0: Alive
-      200: Critical
-      240: Dead
+      155: Critical
+      270: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 4.2
     baseSprintSpeed: 2.7
@@ -972,7 +971,7 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 35
+        Brute: 28
         Airloss: 1
       types:
         ParryAble: 1
@@ -981,8 +980,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      900: Critical
-      1100: Dead
+      750: Critical
+      900: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 2.2

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
@@ -371,7 +371,7 @@
     solution:
       reagents:
       - ReagentId: MedievalMyrmexPoison
-        Quantity: 30
+        Quantity: 15
   - type: SpawnOnDespawn
     prototype: MedievalMyrmexTrapEmpty
   - type: Sprite
@@ -677,7 +677,7 @@
     rechargeSound:
       path: /Audio/Imperial/Medieval/ant_acidrecharge.ogg
   - type: BasicEntityAmmoProvider
-    proto: BulletAcid
+    proto: MedievalMyrmexBulletAcid
     capacity: 1
     count: 1
   - type: MeleeWeapon

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
@@ -704,7 +704,7 @@
     thresholds:
       0: Alive
       100: Critical
-      170: Dead
+      120: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.4
     baseSprintSpeed: 2.2
@@ -759,14 +759,14 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 21
+        Brute: 30
       types:
         ParryAble: 1
   - type: MobThresholds
     thresholds:
       0: Alive
-      310: Critical # curse of 220. no. 310
-      450: Dead
+      510: Critical # curse of 220. no. 310. no. 510.
+      650: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 1.8
@@ -821,14 +821,15 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 14
+        Brute: 35
+        Airloss: 1
       types:
         ParryAble: 1
   - type: MobThresholds
     thresholds:
       0: Alive
-      155: Critical
-      270: Dead
+      200: Critical
+      240: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 4.2
     baseSprintSpeed: 2.7
@@ -971,7 +972,7 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 25
+        Brute: 35
         Airloss: 1
       types:
         ParryAble: 1
@@ -980,8 +981,8 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      750: Critical
-      900: Dead
+      900: Critical
+      1100: Dead
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 2.2
@@ -1151,16 +1152,16 @@
 - type: damageModifierSet
   id: MyrmexArmorOff
   coefficients:
-    Blunt: 0.9
-    Slash: 0.9
-    Piercing: 0.9
-    Heat: 0.9
+    Blunt: 0.85
+    Slash: 0.85
+    Piercing: 0.85
+    Heat: 0.85
 
 - type: damageModifierSet
   id: MyrmexArmorOn
   coefficients:
-    Blunt: 0.60
-    Slash: 0.60
-    Piercing: 0.60
-    Heat: 0.60
+    Blunt: 0.55
+    Slash: 0.55
+    Piercing: 0.55
+    Heat: 0.55
 

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexturret.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexturret.yml
@@ -55,7 +55,7 @@
     - type: Projectile
       damage:
         types:
-          Caustic: 4
+          Caustic: 10
     - type: Sprite
       sprite: /Textures/Imperial/Medieval/Myrmex/Structures/Turret/myrmex_acid.rsi
       layers:

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexturret.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexturret.yml
@@ -55,7 +55,7 @@
     - type: Projectile
       damage:
         types:
-          Caustic: 10
+          Caustic: 4
     - type: Sprite
       sprite: /Textures/Imperial/Medieval/Myrmex/Structures/Turret/myrmex_acid.rsi
       layers:

--- a/Resources/Prototypes/Imperial/Medieval/Potions/reagents.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Potions/reagents.yml
@@ -1708,20 +1708,6 @@
   absorbent: true
   flavor: null
   color: "#FFC8C8"
-  reactiveEffects:
-    Acidic:
-      methods: [ Touch ]
-      effects:
-      - !type:HealthChange
-        scaleByQuantity: true
-        ignoreResistances: false
-        damage:
-          types:
-            Caustic: 5
-            Radiation: 5
-      - !type:Emote
-        emote: Scream
-        probability: 0.3
   metabolisms:
     Poison:
       effects:

--- a/Resources/Prototypes/Imperial/Medieval/Potions/reagents.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Potions/reagents.yml
@@ -136,34 +136,22 @@
     amount: -4
   - !type:PlantAdjustHealth
     amount: -8
-  reactiveEffects:
-    Acidic:
-      methods: [ Touch ]
-      effects:
-      - !type:HealthChange
-        scaleByQuantity: true
-        ignoreResistances: false
-        damage:
-          types:
-            Caustic: 6 # 20 caustic on t1??? down to 6.
-      - !type:Emote
-        emote: Scream
-        probability: 0.8
   metabolisms:
     Poison:
+      metabolismRate: 0.1
       effects:
       - !type:HealthChange
         damage:
           types:
-            Caustic: 2
+            Caustic: 1
       - !type:PopupMessage
         type: Local
         visualType: Large
         messages: [ "generic-reagent-effect-burning-insides" ]
-        probability: 0.8
+        probability: 0.3
       - !type:Emote
         emote: Scream
-        probability: 0.8
+        probability: 0.3
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -197,23 +185,14 @@
   plantMetabolism:
   - !type:PlantAdjustMutationLevel
     amount: 1
-  reactiveEffects:
-    Acidic:
-      methods: [ Touch ]
-      effects:
-      - !type:HealthChange
-        scaleByQuantity: true
-        ignoreResistances: false
-        damage:
-          types:
-            Radiation: 6 # 25? rad on t1??? down to 6.
   metabolisms:
     Poison:
+      metabolismRate: 0.2
       effects:
       - !type:HealthChange
         damage:
           types:
-            Radiation: 3
+            Radiation: 1.5
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold
@@ -566,7 +545,7 @@
   physicalDesc: ""
   showinbook: false
   evaporationSpeed: 0.3
-  absorbent: true
+  absorbent: true 
   flavor: null
   color: "#63806e"
   metabolisms:
@@ -1334,25 +1313,12 @@
     amount: -4
   - !type:PlantAdjustHealth
     amount: -8
-  reactiveEffects:
-    Acidic:
-      methods: [ Touch ]
-      effects:
-      - !type:HealthChange
-        scaleByQuantity: true
-        ignoreResistances: true
-        damage:
-          types:
-            Caustic: 6
-            Radiation: 6
-      - !type:Emote
-        emote: Scream
-        probability: 0.8
   metabolisms:
     Medicine:
       effects:
       - !type:DeleteDeathCurseEffect
     Poison:
+      metabolismRate: 0.4
       effects:
       - !type:HealthChange
         damage:
@@ -1363,10 +1329,10 @@
         type: Local
         visualType: Large
         messages: [ "generic-reagent-effect-burning-insides" ]
-        probability: 0.7
+        probability: 0.5
       - !type:Emote
         emote: Scream
-        probability: 0.7
+        probability: 0.5
       - !type:Jitter
         conditions:
         - !type:ReagentThreshold

--- a/Resources/Prototypes/Imperial/Medieval/Potions/reagents.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Potions/reagents.yml
@@ -545,7 +545,7 @@
   physicalDesc: ""
   showinbook: false
   evaporationSpeed: 0.3
-  absorbent: true 
+  absorbent: true
   flavor: null
   color: "#63806e"
   metabolisms:

--- a/Resources/Prototypes/Imperial/Medieval/armor.yml
+++ b/Resources/Prototypes/Imperial/Medieval/armor.yml
@@ -3098,8 +3098,8 @@
   - type: StaminaResistance
     damageCoefficient: 0.5
   - type: ClothingSpeedModifier
-    walkModifier: 0.93
-    sprintModifier: 0.93
+    walkModifier: 0.98
+    sprintModifier: 0.98
   - type: Item
     size: Normal
   - type: ExplosionResistance

--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -99,8 +99,8 @@
     range: 1
     damage:
       types:
-        Slash: 9
-        Caustic: 3
+        Slash: 11
+        Caustic: 1
         ParryAble: 1
     resetOnHandSelected: false
     soundHit:
@@ -156,8 +156,8 @@
     range: 1.15
     damage:
       types:
-        Slash: 16
-        Caustic: 3
+        Slash: 17.5
+        Caustic: 1.5
         ParryAble: 1
     resetOnHandSelected: false
     soundHit:
@@ -251,8 +251,8 @@
     range: 2.4
     damage:
       types:
-        Piercing: 15
-        Caustic: 4
+        Piercing: 17
+        Caustic: 2
         ParryAble: 1
     angle: 0
     animation: CP14WeaponArcThrust
@@ -422,9 +422,9 @@
     attackRate: 0.8
     damage:
       types:
-        Blunt: 7.5
-        Piercing: 6
-        Caustic: 3.5
+        Blunt: 8.5
+        Piercing: 7
+        Caustic: 1.5
         ParryAble: 1
     animation: CP14WeaponArcThrust
     wideAnimation: CP14WeaponArcSlash
@@ -4033,8 +4033,8 @@
     range: 1
     damage:
       types:
-        Slash: 6
-        Poison: 3
+        Slash: 8.5
+        Poison: 0.5
         ParryAble: 1
     soundHit:
       path: /Audio/Imperial/Medieval/ES_Knife_Stab_2_-_SFX_Producer.ogg

--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -419,7 +419,7 @@
   - type: MeleeWeapon
     clickDamageModifier: 1.26
     wideAnimationRotation: -140
-    attackRate: 1.2
+    attackRate: 0.8
     damage:
       types:
         Blunt: 7.5
@@ -1927,7 +1927,7 @@
   - type: MeleeWeapon
     clickDamageModifier: 1.26
     wideAnimationRotation: -140
-    attackRate: 1.1
+    attackRate: 0.8
     animation: CP14WeaponArcThrust
     wideAnimation: CP14WeaponArcSlash
     cPSwingBeverage: true
@@ -1994,7 +1994,7 @@
   - type: MeleeWeapon
     clickDamageModifier: 1.26
     wideAnimationRotation: -140
-    attackRate: 1.1
+    attackRate: 0.8
     animation: CP14WeaponArcThrust
     wideAnimation: CP14WeaponArcSlash
     cPSwingBeverage: true
@@ -3480,7 +3480,7 @@
     cPAnimationOffset: 1
     clickDamageModifier: 1.26
     wideAnimationRotation: -140
-    attackRate: 1.1
+    attackRate: 0.8
     damage:
       types:
         Blunt: 7.5

--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -23,7 +23,7 @@
   - type: Sharp
   - type: MeleeWeapon
     wideAnimationRotation: -140
-    attackRate: 0.5
+    attackRate: 0.8
     range: 2.15
     damage:
       types:
@@ -246,7 +246,7 @@
     parryChanse: 0.45
   - type: MeleeWeapon
     wideAnimationRotation: -140
-    attackRate: 0.65
+    attackRate: 0.8
     clickDamageModifier: 1.28
     range: 2.4
     damage:
@@ -1739,7 +1739,7 @@
   - type: MeleeWeapon
     clickDamageModifier: 1.28
     wideAnimationRotation: -140
-    attackRate: 0.65
+    attackRate: 0.8
     range: 2.4
     damage:
       types:
@@ -1835,7 +1835,7 @@
   - type: MeleeWeapon
     clickDamageModifier: 1.28
     wideAnimationRotation: -140
-    attackRate: 0.65
+    attackRate: 0.8
     range: 2.25
     damage:
       types:
@@ -3379,7 +3379,7 @@
   - type: MeleeWeapon
     clickDamageModifier: 1.28
     wideAnimationRotation: -140
-    attackRate: 0.6
+    attackRate: 0.8
     range: 2.4
     damage:
       types:


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

<!--
    Тип изменения, может быть одним из следующих:
    - feat
    - tweak
    - fix
    - remove

    Ставьте feat, если вы что-то добавили.
    Ставьте tweak, если вы изменили баланс или механику.
    Ставьте fix, если это исправление чего-то.
    Ставьте remove, если вы что-то удалили или ревертнули

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда ставьте feat
-->
Тип: tweak
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения:
***RU***
Еще один нерф перка на одноручные булавы. Одноручные булавы, чтобы сбалансировать нерф перка, стали быстрее. Старые булавы пофикшены.

Костяной кинжал и оружие некромантов получили нерф своего АП урона, хотя его все еще много.

Ап перка на арбалеты(чуть чуть)

Копья получили бафф скорости атаки и теперь не являются рофлооружием. Ополченцы ликуют.

Ледяной дракон теперь стреляет реже(раз в 4 секунды), но СИЛЬНО больнее - 25 урона. В целом ДПС стал меньше, ледяной дракон стал менее токсичным.

Огненная стена слабее замедляет при касте, ускорение каста с прокачкой, в целом прокаст стал сильно быстрее чем был.

Бафф санстрайка.

Заклинание сна стало чуть дороже.

Т3 дым стал ослеплять меньше.

Отныне яды наносят урон постепенно, но много:
***ЗА 2 ЮНИТА***
Т2 acid - 20 урона за 20 секунд
T2 radiation - 15 урона за 10 секунд
T3 - 60 урона за 5 секунд

Бригантина стала мобильнее.

Мирмексы занерфлены - ловушка, турель и плевок плевателя наносят меньше урона, так как являются АП.

Мирмексам вырезана раковая опухоль - из-за скейлинга урона от рагу, стандартные 2-4 Airloss и Bloodloss урона за укус достигали абсолютно неадекватных значений, ломая ТТК полностью. АП вырезано у всех кроме королевы, обычный урон повышен. Броня уменьшена, кому надо ХП увеличено.
***EN***

Another nerf to the one-handed mace perk.

A slight buff to the crossbow perk.

Spears received an attack speed buff and are no longer a gimmick weapon. Militiamen rejoice.

The Ice Dragon now fires less frequently (once every 4 seconds) but deals significantly more damage—25 per hit. Overall, DPS has decreased, making the Ice Dragon less toxic overall.

Wall of Fire slows less upon casting; cast speed improves with upgrades, making the overall casting process much faster than before.

Sunstrike buff.

Sleep spell cost slightly increased.

Tier 3 Smoke now causes less blindness.

Poisons now deal damage over time, but in large amounts:
***PER 2 UNITS***
Tier 2 Acid: 20 damage over 20 seconds
Tier 2 Radiation: 15 damage over 10 seconds
Tier 3: 60 damage over 5 seconds

Brigandine mobility increased.

Mirmaling, traps and turrets were nerfed.
<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

*Нет* 

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*
