### PR TITLE
Отдельная погода для каждой карты

### DIFF
--- a/Content.Server/Imperial/Medieval/Ships/Wind/ServerWindSystem.cs
+++ b/Content.Server/Imperial/Medieval/Ships/Wind/ServerWindSystem.cs
@@ -156,16 +156,7 @@ public sealed class ServerWindSystem : EntitySystem
     private void UpdateStormWeather(float stormLevel)
     {
         var rainLevelReached = stormLevel >= _cfg.GetCVar(ShipsCCVars.StormRainLevel);
-        var rainWeatherId = new ProtoId<WeatherPrototype>(_cfg.GetCVar(ShipsCCVars.StormRainWeather));
-        WeatherPrototype? rain = null;
-        if (rainLevelReached && !_prototype.TryIndex(rainWeatherId, out rain))
-            return;
-
         var stormLevelReached = stormLevel >= _cfg.GetCVar(ShipsCCVars.StormStormLevel);
-        var stormWeatherId = new ProtoId<WeatherPrototype>(_cfg.GetCVar(ShipsCCVars.StormStormWeather));
-        WeatherPrototype? storm = null;
-        if (stormLevelReached && !_prototype.TryIndex(stormWeatherId, out storm))
-            return;
 
         var seaMaps = new HashSet<MapId>();
         foreach (var seaComp in EntityManager.EntityQuery<SeaComponent>())
@@ -177,14 +168,50 @@ public sealed class ServerWindSystem : EntitySystem
             if (mapId == MapId.Nullspace || !seaMaps.Add(mapId))
                 continue;
 
+            if (stormLevelReached)
+            {
+                if (seaComp.StormWeather == null)
+                {
+                    Log.Error($"Unable to set storm weather for sea {ToPrettyString(seaComp.Owner)}: " +
+                              $"{nameof(SeaComponent.StormWeather)} is null.");
+                    return;
+                }
+
+                if (!_prototype.TryIndex(seaComp.StormWeather, out var storm, false))
+                {
+                    Log.Error($"Unable to set storm weather for sea {ToPrettyString(seaComp.Owner)}: " +
+                              $"prototype '{seaComp.StormWeather}' was not found.");
+                    return;
+                }
+
+                _weather.SetWeather(mapId, storm, null);
+                continue;
+            }
+
             if (rainLevelReached)
-                _weather.SetWeather(mapId, rain!, null);
-            else
+            {
+                if (seaComp.RainWeather == null)
+                {
+                    Log.Error($"Unable to set rain weather for sea {ToPrettyString(seaComp.Owner)}: " +
+                              $"{nameof(SeaComponent.RainWeather)} is null.");
+                    return;
+                }
+
+                if (!_prototype.TryIndex(seaComp.RainWeather, out var rain, false))
+                {
+                    Log.Error($"Unable to set rain weather for sea {ToPrettyString(seaComp.Owner)}: " +
+                              $"prototype '{seaComp.RainWeather}' was not found.");
+                    return;
+                }
+
+                _weather.SetWeather(mapId, rain, null);
+                continue;
+            }
+
+            if (seaComp.RainWeather is { } rainWeatherId)
                 DisableWeather(mapId, rainWeatherId);
 
-            if (stormLevelReached)
-                _weather.SetWeather(mapId, storm!, null);
-            else
+            if (seaComp.StormWeather is { } stormWeatherId)
                 DisableWeather(mapId, stormWeatherId);
         }
     }

--- a/Content.Shared/Imperial/Medieval/Administration/Ships/ShipsCCVars.cs
+++ b/Content.Shared/Imperial/Medieval/Administration/Ships/ShipsCCVars.cs
@@ -60,12 +60,8 @@ public sealed class ShipsCCVars : CVars
         CVarDef.Create("ships.stormmaxlevel", 8f, CVar.REPLICATED | CVar.SERVER);
     public static readonly CVarDef<float> StormRainLevel =  // С какого уровня шторма начинается дождь
         CVarDef.Create("ships.stormrainlevel", 4f, CVar.REPLICATED | CVar.SERVER);
-    public static readonly CVarDef<string> StormRainWeather =
-        CVarDef.Create("ships.stormrainweather", "Rain", CVar.REPLICATED | CVar.SERVER);
     public static readonly CVarDef<float> StormStormLevel = // С какого уровня шторма начинается шторм
         CVarDef.Create("ships.stormstormlevel", 5f, CVar.REPLICATED | CVar.SERVER);
-    public static readonly CVarDef<string> StormStormWeather =
-        CVarDef.Create("ships.stormstormweather", "Storm", CVar.REPLICATED | CVar.SERVER);
     /// <summary>
     /// скорость с которой волна спавнится
     /// </summary>

--- a/Content.Shared/Imperial/Medieval/Ships/Sea/SeaComponent.cs
+++ b/Content.Shared/Imperial/Medieval/Ships/Sea/SeaComponent.cs
@@ -1,4 +1,6 @@
+using Content.Shared.Weather;
 using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
 
 namespace Content.Shared.Imperial.Medieval.Ships.Sea;
 
@@ -28,4 +30,10 @@ public sealed partial class SeaComponent : Component
 
     [DataField]
     public int InitStormLevel = 1;
+
+    [DataField]
+    public ProtoId<WeatherPrototype>? RainWeather = "Rain";
+
+    [DataField]
+    public ProtoId<WeatherPrototype>? StormWeather = "Storm";
 }


### PR DESCRIPTION
Прототипы погоды при достижении определённого уровня штормы убраны из cvar в компонент моря

Благодаря этому, каждой карте можно задавать собственную погоду при шторме. 

По умолчанию, это всё ещё дождь и шторм