### PR TITLE
Фикс мирмексов и манарегена

### DIFF
--- a/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaComponent.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaComponent.cs
@@ -8,6 +8,8 @@ namespace Content.Shared.Imperial.Medieval.Magic.Mana;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ManaComponent : Component
 {
+    public const float DefaultRegenMultiplier = 10f;
+
     [DataField]
     public float RegenRaceModifier = 1f;
 
@@ -22,6 +24,9 @@ public sealed partial class ManaComponent : Component
 
     [DataField, AutoNetworkedField]
     public float Regen = 0.25f;
+
+    [DataField, AutoNetworkedField]
+    public float RegenMultiplier = DefaultRegenMultiplier;
 
 
     [DataField]

--- a/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaRegen/ManaRegenSystem.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaRegen/ManaRegenSystem.cs
@@ -43,7 +43,14 @@ public sealed partial class ManaRegenSystem : EntitySystem
 
     private void OnExamine(EntityUid uid, ManaRegenComponent component, ExaminedEvent args)
     {
-        args.PushMarkup(Loc.GetString(component.ManaRegenMessage, ("regen", Math.Round(component.Regen, 3))));
+        var regenMultiplier = TryComp<ManaComponent>(args.Examiner, out var manaComponent)
+            ? manaComponent.RegenMultiplier
+            : ManaComponent.DefaultRegenMultiplier;
+
+        args.PushMarkup(Loc.GetString(
+            component.ManaRegenMessage,
+            ("regen", Math.Round(component.Regen * regenMultiplier, 3))
+        ));
     }
 
     private void OnEquip(EntityUid uid, ManaRegenComponent component, GotEquippedEvent args)

--- a/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaSystem.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaSystem.cs
@@ -27,6 +27,7 @@ public sealed partial class ManaSystem : EntitySystem
 
         SubscribeLocalEvent<ManaDrainSpellComponent, MedievalBeforeCastSpellEvent>(OnBeforeCast);
         SubscribeLocalEvent<ManaDrainSpellComponent, MedievalAfterCastSpellEvent>(OnAfterCast);
+        SubscribeLocalEvent<ManaDrainSpellComponent, MedievalFailCastSpellEvent>(OnFailCast);
         SubscribeLocalEvent<ManaMaxModifierComponent, ComponentStartup>(MaxManaModify);
         SubscribeLocalEvent<ManaRegenModifierComponent, ComponentStartup>(RegenModify);
     }
@@ -104,17 +105,20 @@ public sealed partial class ManaSystem : EntitySystem
             return;
         }
 
+        if (manaComponent.CastedSpells.ContainsKey(uid))
+            return;
+
         if (manaComponent.Mana - GetAllSpellsManaDrain(manaComponent.CastedSpells) - component.ManaDrain < 0)
         {
-            if (component.CanUseWithoutMana) manaComponent.CastedSpells.TryAdd(uid, component.ManaDrain);
+            if (component.CanUseWithoutMana) manaComponent.CastedSpells[uid] = component.ManaDrain;
             if (_timing.IsFirstTimePredicted && _net.IsServer) _popupSystem.PopupEntity(Loc.GetString(component.ManaLowMessage), args.Performer, args.Performer, PopupType.LargeCaution);
 
             args.Cancelled = !component.CanUseWithoutMana;
 
             return;
         }
-        manaComponent.CastedSpells.Clear();
-        manaComponent.CastedSpells.TryAdd(uid, component.ManaDrain);
+
+        manaComponent.CastedSpells[uid] = component.ManaDrain;
     }
 
     private void OnAfterCast(EntityUid uid, ManaDrainSpellComponent component, ref MedievalAfterCastSpellEvent args)
@@ -126,9 +130,16 @@ public sealed partial class ManaSystem : EntitySystem
         if (manaComponent.Mana - component.ManaDrain < 0)
             _damageableSystem.TryChangeDamage(args.Performer, component.DamageOnUseWithoutMana, true, false);
 
-        TryChargeMana(args.Performer, -component.ManaDrain);
+        TryChangeMana(args.Performer, manaComponent.Mana - component.ManaDrain, manaComponent);
 
         if (_timing.IsFirstTimePredicted && _net.IsServer) _popupSystem.PopupEntity(Loc.GetString("medieval-mana-cast-spell", ("manaCost", component.ManaDrain)), args.Performer, args.Performer, PopupType.Large);
+    }
+
+    private void OnFailCast(EntityUid uid, ManaDrainSpellComponent component, ref MedievalFailCastSpellEvent args)
+    {
+        if (!TryComp<ManaComponent>(args.Performer, out var manaComponent)) return;
+
+        manaComponent.CastedSpells.Remove(uid);
     }
 
     #region Helpers
@@ -142,9 +153,8 @@ public sealed partial class ManaSystem : EntitySystem
     public bool TryChangeMana(EntityUid uid, float mana, ManaComponent? component = null)
     {
         if (!Resolve(uid, ref component)) return false;
-        if (component.Mana > component.MaxMana) return false;
 
-        component.Mana = mana < 0 ? 0 : mana;
+        component.Mana = Math.Clamp(mana, 0f, component.MaxMana);
 
         Dirty(uid, component);
 
@@ -154,9 +164,12 @@ public sealed partial class ManaSystem : EntitySystem
     public bool TryChargeMana(EntityUid uid, float mana, ManaComponent? component = null)
     {
         if (!Resolve(uid, ref component)) return false;
-        if (component.Mana + mana > component.MaxMana) return false;
 
-        component.Mana = component.Mana + mana * 10f < 0 ? 0 : component.Mana + mana * 10f;
+        component.Mana = Math.Clamp(
+            component.Mana + mana * component.RegenMultiplier,
+            0f,
+            component.MaxMana
+        );
 
         Dirty(uid, component);
 

--- a/Content.Shared/Imperial/Medieval/Magic/Other/Spells/MedievalSpellTeleportEffect/SharedMedievalSpellTeleportEffectSystem.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/Other/Spells/MedievalSpellTeleportEffect/SharedMedievalSpellTeleportEffectSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Actions;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Examine;
 using Content.Shared.Imperial.PhaseSpace;
+using Content.Shared.Imperial.Medieval.Magic.Mana;
 using Content.Shared.Interaction;
 using Content.Shared.Maps;
 using Content.Shared.Physics;
@@ -27,7 +28,10 @@ public abstract partial class SharedMedievalSpellTeleportEffectSystem : EntitySy
     {
         base.Initialize();
 
-        SubscribeLocalEvent<MedievalSpellTeleportEffectComponent, MedievalBeforeCastSpellEvent>(OnBeforeCast);
+        SubscribeLocalEvent<MedievalSpellTeleportEffectComponent, MedievalBeforeCastSpellEvent>(
+            OnBeforeCast,
+            before: new[] { typeof(ManaSystem) }
+        );
         SubscribeLocalEvent<MedievalSpellTeleportEffectComponent, MedievalAfterCastSpellEvent>(OnAfterCast);
     }
 

--- a/Content.Shared/Imperial/Medieval/Magic/SharedMedievalMagicSystem.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/SharedMedievalMagicSystem.cs
@@ -63,14 +63,20 @@ public abstract partial class SharedMedievalMagicSystem : EntitySystem
 
         _speedModifierSystem.RefreshMovementSpeedModifiers(uid);
 
-        if (_handsSystem.TryGetEmptyHand(args.User, out _) == false)
+        if (args.Cancelled)
         {
-            _popupSystem.PopupClient(Loc.GetString("medieval-magic-free-hand-required"), args.User);
+            RaiseLocalEvent(GetEntity(spellData.Action), new MedievalFailCastSpellEvent()
+            {
+                Action = GetEntity(spellData.Action),
+                Performer = uid
+            });
+
             return;
         }
 
-        if (args.Cancelled)
+        if (_handsSystem.TryGetEmptyHand(args.User, out _) == false)
         {
+            _popupSystem.PopupClient(Loc.GetString("medieval-magic-free-hand-required"), args.User);
             RaiseLocalEvent(GetEntity(spellData.Action), new MedievalFailCastSpellEvent()
             {
                 Action = GetEntity(spellData.Action),
@@ -103,13 +109,17 @@ public abstract partial class SharedMedievalMagicSystem : EntitySystem
 
     #region Helpers
 
-    protected bool PassesSpellPrerequisites(EntityUid spell, EntityUid performer, EntityCoordinates target)
+    protected bool PassesSpellPrerequisites(
+        EntityUid spell,
+        EntityUid performer,
+        EntityCoordinates target
+    )
     {
+        if (_handsSystem.TryGetEmptyHand(performer, out _) == false)
+            return false;
+
         var ev = new MedievalBeforeCastSpellEvent(performer, target);
         RaiseLocalEvent(spell, ref ev);
-
-        if (_handsSystem.TryGetEmptyHand(performer, out _) == false) // TODO: Если в игре появятся магические катализаторы (посохи, палочки), что дают баффы при сотворении чар, то нужно будет добавить их в исключение
-            return false;
 
         return !ev.Cancelled;
     }

--- a/Content.Shared/Imperial/Medieval/Myrmex/SharedMyrmexHungerSystem.cs
+++ b/Content.Shared/Imperial/Medieval/Myrmex/SharedMyrmexHungerSystem.cs
@@ -2,8 +2,12 @@
 using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Examine;
+using Content.Shared.Imperial.Dash;
+using Content.Shared.Imperial.Medieval.Sprint;
 using Content.Shared.Movement.Systems;
+using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee.Events;
+using Content.Shared.Weapons.Ranged.Systems;
 using Content.Shared.Myrmex.Hive;
 using Robust.Shared.Network;
 using Robust.Shared.Timing;
@@ -23,8 +27,11 @@ namespace Content.Shared.Imperial.Medieval.Myrmex
             base.Initialize();
             SubscribeLocalEvent<MyrmexHungerComponent, RefreshMovementSpeedModifiersEvent>(OnSpeedRefresh);
             SubscribeLocalEvent<MyrmexHungerComponent, ComponentInit>(OnInit);
-            SubscribeLocalEvent<MyrmexHungerComponent, StaminaModifyEvent>(OnModifyStaminaDamage);
+            SubscribeLocalEvent<MyrmexHungerComponent, BeforeStaminaDamageEvent>(OnModifyStaminaDamage);
+            SubscribeLocalEvent<MyrmexHungerComponent, GetSprintStaminaDamageModifiersEvent>(OnModifySprintStaminaCost);
+            SubscribeLocalEvent<MyrmexHungerComponent, CheckDashStaminaCostModifiersEvent>(OnModifyDashStaminaCost);
             SubscribeLocalEvent<MyrmexHungerComponent, GetMeleeDamageEvent>(OnGetDamage);
+            SubscribeLocalEvent<MyrmexHungerComponent, GunShotEvent>(OnGunShot);
             SubscribeLocalEvent<MyrmexHungerComponent, DamageModifyEvent>(OnGetDamageModifiers);
             SubscribeLocalEvent<MyrmexHungerComponent, ExaminedEvent>(OnExamined);
         }
@@ -63,16 +70,50 @@ namespace Content.Shared.Imperial.Medieval.Myrmex
             args.PushMarkup(Loc.GetString("medieval-myrmex-buff-stamina-examine", ("value", Math.Round(buff.Stamina, 2))));
         }
 
-        private void OnModifyStaminaDamage(EntityUid uid, MyrmexHungerComponent comp, StaminaModifyEvent args)
+        private void OnModifyStaminaDamage(EntityUid uid, MyrmexHungerComponent comp, ref BeforeStaminaDamageEvent args)
+        {
+            if (args.Value <= 0f)
+                return;
+
+            var buff = MyrmexBuff.MultiplyBuffs(comp.Buffs);
+            args.Value *= buff.Stamina;
+        }
+
+        private void OnModifySprintStaminaCost(EntityUid uid, MyrmexHungerComponent comp, ref GetSprintStaminaDamageModifiersEvent args)
         {
             var buff = MyrmexBuff.MultiplyBuffs(comp.Buffs);
-            args.Damage *= buff.Stamina;
+            args.Modifier *= buff.Stamina;
+        }
+
+        private void OnModifyDashStaminaCost(EntityUid uid, MyrmexHungerComponent comp, ref CheckDashStaminaCostModifiersEvent args)
+        {
+            var buff = MyrmexBuff.MultiplyBuffs(comp.Buffs);
+            args.Modifier *= buff.Stamina;
         }
 
         private void OnGetDamage(EntityUid uid, MyrmexHungerComponent comp, ref GetMeleeDamageEvent args)
         {
+            if (!args.RaisedOnUser)
+                return;
+
             var buff = MyrmexBuff.MultiplyBuffs(comp.Buffs);
-            args.Damage *= buff.Damage;
+            var damage = args.Damage * buff.Damage;
+
+            if (args.Damage.DamageDict.TryGetValue("ParryAble", out var parryAble))
+                damage.DamageDict["ParryAble"] = parryAble;
+
+            args.Damage = damage;
+        }
+
+        private void OnGunShot(EntityUid uid, MyrmexHungerComponent comp, ref GunShotEvent args)
+        {
+            var buff = MyrmexBuff.MultiplyBuffs(comp.Buffs);
+
+            foreach (var (ammo, _) in args.Ammo)
+            {
+                if (TryComp<ProjectileComponent>(ammo, out var projectile))
+                    projectile.Damage *= buff.Damage;
+            }
         }
 
         private void OnGetDamageModifiers(EntityUid uid, MyrmexHungerComponent comp, ref DamageModifyEvent args)

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
@@ -677,7 +677,7 @@
     rechargeSound:
       path: /Audio/Imperial/Medieval/ant_acidrecharge.ogg
   - type: BasicEntityAmmoProvider
-    proto: BulletAcid
+    proto: MedievalMyrmexSpitterBulletAcid
     capacity: 1
     count: 1
   - type: MeleeWeapon
@@ -736,6 +736,17 @@
     passiveVisibilityRate: -0.3
     movementVisibilityRate: 0.7
   - type: MedievalUnthrowable
+
+- type: entity
+  id: MedievalMyrmexSpitterBulletAcid
+  parent: BulletAcid
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: Projectile
+    damage:
+      types:
+        Caustic: 2.0
+        Blunt: 3.0
 
 - type: entity
   name: myrmalisk


### PR DESCRIPTION
Супы больше не умножают урон мирмексов дважды, и не трогают ParryAble тип урона

Множитель расхода выносливости теперь действительно работает и умножает любой входящий стамина-урон, в том числе дэш и бег

Манареген теперь не добавляет ману сверх максимальной, и корректно работает с пограничными значениями текущей и максимальной маны