### PR TITLE
Halved Wandering Mage grimoire point

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/Magic/spell_books.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/spell_books.yml
@@ -70,12 +70,12 @@
   components:
   - type: ImperialStore
     balance:
-      MagicMedievalFire: 70
-      MagicMedievalLight: 70
-      MagicMedievalVodka: 70
-      MagicMedievalEarth: 70
+      MagicMedievalFire: 25
+      MagicMedievalLight: 25
+      MagicMedievalVodka: 25
+      MagicMedievalEarth: 25
       MagicMedievalDarkness: 0
-      ArchmagePoints: 2
+      ArchmagePoints: 1
 
 - type: entity
   parent: MedievalSpellBookBase


### PR DESCRIPTION
## About this PR
<!-- This information will appear in the changelog; please fill it out -->

<!--
Change type (choose one):
- feat (new feature/content)
- tweak (balance or mechanic adjustment)
- fix (bug fix)
- remove (removal or reversion of changes)

Use 'feat' if you added something.
Use 'tweak' if you changed balance or mechanics.
Use 'fix' if you are fixing a bug.
Use 'remove' if you removed or reverted something.

Always use 'feat' when adding, changing, or removing event content.
-->
Type: tweak
<!--
What exactly did you change?
Keep it brief and write in the third person.
Do not use line breaks.
Example: "Toolbox damage doubled"

Always write "Event content" when adding, changing, or removing event content.
-->
Changes: The point value for the wandering mage has been halved, as there is no reason why a wandering mage (who lacks formal magical training) should receive the same number of points as a mage from the Collegium.

<!--
Example of correct formatting:

Type: tweak
Changes: The point value for the wandering mage spellbook has been halved, as there is no reason why a wandering mage (who lacks formal magical training) should receive the same number of points as a mage from the Collegium
-->

## Technical details
<!-- Brief description of code changes to facilitate review. -->

*None*

## Official code changes from developers
<!-- Brief description of source code (upstream) changes to facilitate review (if applicable). -->

*None*