### PR TITLE
Fix medieval identity introductions

### DIFF
--- a/Content.IntegrationTests/Tests/Imperial/Medieval/MedievalIdentityTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/MedievalIdentityTest.cs
@@ -1,0 +1,194 @@
+using System.Linq;
+using System.Numerics;
+using Content.Client.Verbs;
+using Content.Shared.IdentityManagement;
+using Content.Shared.Imperial.Medieval.IdentityManagement;
+using Content.Shared.Imperial.LocalLight;
+using Content.Shared.Stunnable;
+using Content.Shared.Verbs;
+using Robust.Server.Player;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Localization;
+
+namespace Content.IntegrationTests.Tests.Imperial.Medieval;
+
+[TestFixture]
+public sealed class MedievalIdentityTest
+{
+    [Test]
+    public async Task IntroductionVerbSynchronizesThroughNetworkRequest()
+    {
+        var settings = new PoolSettings { Connected = true };
+        await using var pair = await PoolManager.GetServerClient(settings);
+        var server = pair.Server;
+        var client = pair.Client;
+        var map = await pair.CreateTestMap();
+
+        var serverEntities = server.ResolveDependency<IEntityManager>();
+        var clientEntities = client.ResolveDependency<IEntityManager>();
+        var serverPlayerManager = server.ResolveDependency<IPlayerManager>();
+        var serverSession = serverPlayerManager.Sessions.Single();
+        EntityUid introducer = default;
+        EntityUid observer = default;
+
+        await server.WaitPost(() =>
+        {
+            introducer = serverEntities.SpawnEntity("MobHuman", map.GridCoords);
+            serverEntities.RemoveComponent<LocalLightComponent>(introducer);
+            serverEntities.System<MetaDataSystem>().SetEntityName(introducer, "Introducer Name");
+            serverPlayerManager.SetAttachedEntity(serverSession, introducer);
+
+            observer = serverEntities.SpawnEntity("MobHuman", map.GridCoords);
+            serverEntities.RemoveComponent<LocalLightComponent>(observer);
+        });
+        await pair.RunTicksSync(5);
+
+        var clientIntroducer = client.Session!.AttachedEntity!.Value;
+        var observerNet = serverEntities.GetNetEntity(observer);
+        var clientObserver = clientEntities.GetEntity(observerNet);
+
+        await server.WaitPost(() => serverEntities.EnsureComponent<StunnedComponent>(introducer));
+        await pair.RunTicksSync(5);
+
+        await client.WaitAssertion(() =>
+        {
+            var verbs = client.System<VerbSystem>()
+                .GetLocalVerbs(clientObserver, clientIntroducer, typeof(AlternativeVerb), force: false);
+            Assert.That(verbs.Any(verb => verb.Text == Loc.GetString("imperial-hm-identity-intrd")), Is.False);
+        });
+
+        await client.WaitAssertion(() =>
+        {
+            var verbs = client.System<VerbSystem>()
+                .GetLocalVerbs(clientObserver, clientIntroducer, typeof(AlternativeVerb), force: true);
+            var introduce = verbs.Single(verb => verb.Text == Loc.GetString("imperial-hm-identity-intrd"));
+            client.System<VerbSystem>().ExecuteVerb(introduce, clientIntroducer, clientObserver, forced: true);
+        });
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var introducerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(introducer);
+            var observerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(observer);
+            Assert.That(observerComp.KnownIds, Does.Not.Contain(introducerComp.Identifier));
+        });
+
+        await server.WaitPost(() => serverEntities.RemoveComponent<StunnedComponent>(introducer));
+        await pair.RunTicksSync(5);
+
+        await client.WaitAssertion(() =>
+        {
+            var verbs = client.System<VerbSystem>()
+                .GetLocalVerbs(clientObserver, clientIntroducer, typeof(AlternativeVerb), force: true);
+            var introduce = verbs.Single(verb => verb.Text == Loc.GetString("imperial-hm-identity-intrd"));
+            client.System<VerbSystem>().ExecuteVerb(introduce, clientIntroducer, clientObserver, forced: true);
+        });
+
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var introducerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(introducer);
+            var observerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(observer);
+            Assert.That(observerComp.KnownIds, Does.Contain(introducerComp.Identifier));
+            Assert.That(Identity.Name(introducer, serverEntities, observer), Is.EqualTo("Introducer Name"));
+        });
+
+        await client.WaitAssertion(() =>
+        {
+            var verbs = client.System<VerbSystem>()
+                .GetLocalVerbs(clientObserver, clientIntroducer, typeof(AlternativeVerb), force: true);
+            Assert.That(verbs.Any(verb => verb.Text == Loc.GetString("imperial-hm-identity-intrd")), Is.False);
+            Assert.That(Identity.Name(clientIntroducer, clientEntities, clientObserver), Is.EqualTo("Introducer Name"));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task IntroductionSynchronizesDirectionalIdentityKnowledge()
+    {
+        var settings = new PoolSettings { Connected = true };
+        await using var pair = await PoolManager.GetServerClient(settings);
+        var server = pair.Server;
+        var client = pair.Client;
+        var map = await pair.CreateTestMap();
+
+        var serverEntities = server.ResolveDependency<IEntityManager>();
+        var clientEntities = client.ResolveDependency<IEntityManager>();
+        var serverIdentity = server.System<Content.Server.Imperial.Medieval.IdentityManagement.MedievalIdentitySystem>();
+
+        EntityUid introducer = default;
+        EntityUid observer = default;
+        await server.WaitPost(() =>
+        {
+            EntityUid SpawnIdentityHolder(string name)
+            {
+                var holder = serverEntities.SpawnEntity("MobHuman", map.GridCoords);
+                serverEntities.RemoveComponent<LocalLightComponent>(holder);
+                serverEntities.System<MetaDataSystem>().SetEntityName(holder, name);
+                return holder;
+            }
+
+            introducer = SpawnIdentityHolder("Introducer Name");
+            observer = SpawnIdentityHolder("Observer Name");
+        });
+        await pair.RunTicksSync(5);
+
+        var introducerId = 0;
+        await server.WaitAssertion(() =>
+        {
+            var introducerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(introducer);
+            var observerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(observer);
+            var unknownName = Identity.Name(introducer, serverEntities, observer);
+            introducerId = introducerComp.Identifier;
+
+            Assert.That(unknownName, Is.Not.EqualTo("Introducer Name"));
+            Assert.That(observerComp.KnownIds, Does.Not.Contain(introducerComp.Identifier));
+            Assert.That(introducerComp.KnownIds, Does.Not.Contain(observerComp.Identifier));
+            Assert.That(serverIdentity.CanIntroduce(introducer, observer), Is.True);
+        });
+
+        await server.WaitAssertion(() =>
+        {
+            var introducerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(introducer);
+            var observerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(observer);
+
+            serverEntities.System<SharedTransformSystem>().SetLocalPosition(observer, new Vector2(20f, 20f));
+            Assert.That(serverIdentity.Introduce(introducer, observer), Is.False);
+            Assert.That(observerComp.KnownIds, Does.Not.Contain(introducerComp.Identifier));
+
+            serverEntities.System<SharedTransformSystem>().SetLocalPosition(observer, Vector2.Zero);
+
+            serverEntities.EnsureComponent<StunnedComponent>(introducer);
+            Assert.That(serverIdentity.Introduce(introducer, observer), Is.False);
+            Assert.That(observerComp.KnownIds, Does.Not.Contain(introducerComp.Identifier));
+            serverEntities.RemoveComponent<StunnedComponent>(introducer);
+
+            Assert.That(serverIdentity.Introduce(introducer, observer), Is.True);
+            Assert.That(observerComp.KnownIds, Does.Contain(introducerComp.Identifier));
+            Assert.That(Identity.Name(introducer, serverEntities, observer), Is.EqualTo("Introducer Name"));
+            Assert.That(introducerComp.KnownIds, Does.Not.Contain(observerComp.Identifier));
+            Assert.That(Identity.Name(observer, serverEntities, introducer), Is.Not.EqualTo("Observer Name"));
+            Assert.That(serverIdentity.CanIntroduce(introducer, observer), Is.False);
+            Assert.That(serverIdentity.Introduce(introducer, observer), Is.False);
+            Assert.That(observerComp.KnownIds.Count(id => id == introducerComp.Identifier), Is.EqualTo(1));
+        });
+
+        await pair.RunTicksSync(5);
+
+        var introducerNet = serverEntities.GetNetEntity(introducer);
+        var observerNet = serverEntities.GetNetEntity(observer);
+        await client.WaitAssertion(() =>
+        {
+            var clientIntroducer = clientEntities.GetEntity(introducerNet);
+            var clientObserver = clientEntities.GetEntity(observerNet);
+            var clientObserverComp = clientEntities.GetComponent<IdentityRequiresKnowledgeComponent>(clientObserver);
+
+            Assert.That(clientObserverComp.KnownIds, Does.Contain(introducerId));
+            Assert.That(Identity.Name(clientIntroducer, clientEntities, clientObserver), Is.EqualTo("Introducer Name"));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/MedievalIdentityTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/MedievalIdentityTest.cs
@@ -4,6 +4,7 @@ using Content.Client.Verbs;
 using Content.Shared.IdentityManagement;
 using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Imperial.Medieval.IdentityManagement;
+using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
@@ -226,6 +227,64 @@ public sealed class MedievalIdentityTest
 
             Assert.That(clientObserverComp.KnownIds, Does.Contain(introducerId));
             Assert.That(Identity.Name(clientIntroducer, clientEntities, clientObserver), Is.EqualTo("Introducer Name"));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task LearnedIdentityPersistsAcrossVisualDisguises()
+    {
+        await using var pair = await PoolManager.GetServerClient();
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+
+        var entities = server.ResolveDependency<IEntityManager>();
+        var identity = server.System<Content.Server.Imperial.Medieval.IdentityManagement.MedievalIdentitySystem>();
+        var inventory = server.System<InventorySystem>();
+
+        EntityUid introducer = default;
+        EntityUid observer = default;
+        EntityUid helmet = default;
+        EntityUid apron = default;
+
+        await server.WaitPost(() =>
+        {
+            introducer = entities.SpawnEntity("MobHuman", map.GridCoords);
+            observer = entities.SpawnEntity("MobHuman", map.GridCoords);
+            entities.EnsureComponent<IdentityRequiresKnowledgeComponent>(introducer);
+            entities.EnsureComponent<IdentityRequiresKnowledgeComponent>(observer);
+            entities.System<MetaDataSystem>().SetEntityName(introducer, "Introducer Name");
+
+            helmet = entities.SpawnEntity("ClothingHeadHelmetEVA", map.GridCoords);
+            apron = entities.SpawnEntity("ClothingOuterApron", map.GridCoords);
+        });
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(identity.Introduce(introducer, observer), Is.True);
+            Assert.That(Identity.Name(introducer, entities, observer), Is.EqualTo("Introducer Name"));
+            Assert.That(inventory.TryEquip(introducer, helmet, "head"), Is.True);
+        });
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var introducerComp = entities.GetComponent<IdentityRequiresKnowledgeComponent>(introducer);
+            var observerComp = entities.GetComponent<IdentityRequiresKnowledgeComponent>(observer);
+
+            Assert.That(observerComp.KnownIds, Does.Contain(introducerComp.Identifier));
+            Assert.That(Identity.Name(introducer, entities, observer), Is.Not.EqualTo("Introducer Name"));
+
+            Assert.That(inventory.TryUnequip(introducer, "head", true), Is.True);
+            Assert.That(inventory.TryEquip(introducer, apron, "outerClothing"), Is.True);
+        });
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(Identity.Name(introducer, entities, observer), Is.EqualTo("Introducer Name"));
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/MedievalIdentityTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/MedievalIdentityTest.cs
@@ -2,8 +2,9 @@ using System.Linq;
 using System.Numerics;
 using Content.Client.Verbs;
 using Content.Shared.IdentityManagement;
+using Content.Shared.IdentityManagement.Components;
 using Content.Shared.Imperial.Medieval.IdentityManagement;
-using Content.Shared.Imperial.LocalLight;
+using Content.Shared.Popups;
 using Content.Shared.Stunnable;
 using Content.Shared.Verbs;
 using Robust.Server.Player;
@@ -33,19 +34,27 @@ public sealed class MedievalIdentityTest
 
         await server.WaitPost(() =>
         {
-            introducer = serverEntities.SpawnEntity("MobHuman", map.GridCoords);
-            serverEntities.RemoveComponent<LocalLightComponent>(introducer);
+            EntityUid SpawnIdentityHolder()
+            {
+                var holder = serverEntities.CreateEntityUninitialized(null, map.GridCoords);
+                serverEntities.AddComponent<IdentityComponent>(holder);
+                serverEntities.AddComponent<IdentityRequiresKnowledgeComponent>(holder);
+                serverEntities.InitializeAndStartEntity(holder, map.MapId);
+                return holder;
+            }
+
+            introducer = SpawnIdentityHolder();
             serverEntities.System<MetaDataSystem>().SetEntityName(introducer, "Introducer Name");
             serverPlayerManager.SetAttachedEntity(serverSession, introducer);
 
-            observer = serverEntities.SpawnEntity("MobHuman", map.GridCoords);
-            serverEntities.RemoveComponent<LocalLightComponent>(observer);
+            observer = SpawnIdentityHolder();
         });
         await pair.RunTicksSync(5);
 
         var clientIntroducer = client.Session!.AttachedEntity!.Value;
         var observerNet = serverEntities.GetNetEntity(observer);
         var clientObserver = clientEntities.GetEntity(observerNet);
+        var clientTestSystem = client.System<MedievalIdentityTestSystem>();
 
         await server.WaitPost(() => serverEntities.EnsureComponent<StunnedComponent>(introducer));
         await pair.RunTicksSync(5);
@@ -56,6 +65,31 @@ public sealed class MedievalIdentityTest
                 .GetLocalVerbs(clientObserver, clientIntroducer, typeof(AlternativeVerb), force: false);
             Assert.That(verbs.Any(verb => verb.Text == Loc.GetString("imperial-hm-identity-intrd")), Is.False);
         });
+
+        await client.WaitAssertion(() =>
+        {
+            clientTestSystem.PopupCount = 0;
+            var verbs = client.System<VerbSystem>()
+                .GetLocalVerbs(clientObserver, clientIntroducer, typeof(AlternativeVerb), force: true);
+            var introduce = verbs.Single(verb => verb.Text == Loc.GetString("imperial-hm-identity-intrd"));
+            client.System<VerbSystem>().ExecuteVerb(introduce, clientIntroducer, clientObserver, forced: true);
+        });
+        await pair.RunTicksSync(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var introducerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(introducer);
+            var observerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(observer);
+            Assert.That(observerComp.KnownIds, Does.Not.Contain(introducerComp.Identifier));
+        });
+        await client.WaitAssertion(() => Assert.That(clientTestSystem.PopupCount, Is.Zero));
+
+        await server.WaitPost(() => serverEntities.RemoveComponent<StunnedComponent>(introducer));
+        await pair.RunTicksSync(5);
+
+        await server.WaitPost(() =>
+            serverEntities.System<SharedTransformSystem>().SetLocalPosition(observer, new Vector2(20f, 20f)));
+        await pair.RunTicksSync(5);
 
         await client.WaitAssertion(() =>
         {
@@ -72,8 +106,10 @@ public sealed class MedievalIdentityTest
             var observerComp = serverEntities.GetComponent<IdentityRequiresKnowledgeComponent>(observer);
             Assert.That(observerComp.KnownIds, Does.Not.Contain(introducerComp.Identifier));
         });
+        await client.WaitAssertion(() => Assert.That(clientTestSystem.PopupCount, Is.Zero));
 
-        await server.WaitPost(() => serverEntities.RemoveComponent<StunnedComponent>(introducer));
+        await server.WaitPost(() =>
+            serverEntities.System<SharedTransformSystem>().SetLocalPosition(observer, Vector2.Zero));
         await pair.RunTicksSync(5);
 
         await client.WaitAssertion(() =>
@@ -100,6 +136,7 @@ public sealed class MedievalIdentityTest
                 .GetLocalVerbs(clientObserver, clientIntroducer, typeof(AlternativeVerb), force: true);
             Assert.That(verbs.Any(verb => verb.Text == Loc.GetString("imperial-hm-identity-intrd")), Is.False);
             Assert.That(Identity.Name(clientIntroducer, clientEntities, clientObserver), Is.EqualTo("Introducer Name"));
+            Assert.That(clientTestSystem.PopupCount, Is.EqualTo(1));
         });
 
         await pair.CleanReturnAsync();
@@ -124,8 +161,10 @@ public sealed class MedievalIdentityTest
         {
             EntityUid SpawnIdentityHolder(string name)
             {
-                var holder = serverEntities.SpawnEntity("MobHuman", map.GridCoords);
-                serverEntities.RemoveComponent<LocalLightComponent>(holder);
+                var holder = serverEntities.CreateEntityUninitialized(null, map.GridCoords);
+                serverEntities.AddComponent<IdentityComponent>(holder);
+                serverEntities.AddComponent<IdentityRequiresKnowledgeComponent>(holder);
+                serverEntities.InitializeAndStartEntity(holder, map.MapId);
                 serverEntities.System<MetaDataSystem>().SetEntityName(holder, name);
                 return holder;
             }
@@ -190,5 +229,15 @@ public sealed class MedievalIdentityTest
         });
 
         await pair.CleanReturnAsync();
+    }
+}
+
+public sealed class MedievalIdentityTestSystem : EntitySystem
+{
+    public int PopupCount;
+
+    public override void Initialize()
+    {
+        SubscribeNetworkEvent<PopupEntityEvent>(_ => PopupCount++);
     }
 }

--- a/Content.Server/Imperial/Medieval/Identity/MedievalIdentitySystem.cs
+++ b/Content.Server/Imperial/Medieval/Identity/MedievalIdentitySystem.cs
@@ -1,10 +1,14 @@
 using Content.Shared.Administration.Logs;
+using Content.Shared.ActionBlocker;
 using Content.Shared.Database;
+using Content.Shared.IdentityManagement;
 using Content.Shared.Imperial.Medieval.Factions;
 using Content.Shared.Imperial.Medieval.IdentityManagement;
+using Content.Shared.Interaction;
 using Content.Shared.Mind;
 using Content.Shared.Mind.Components;
 using Content.Shared.Players;
+using Content.Shared.Popups;
 using Robust.Server.Player;
 using Robust.Shared.Player;
 
@@ -15,6 +19,9 @@ public sealed class MedievalIdentitySystem : SharedMedievalIdentitySystem
     [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
     [Dependency] private readonly SharedMindSystem _mindSystem = default!;
     [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly SharedPopupSystem _popup = default!;
+    [Dependency] private readonly SharedInteractionSystem _interaction = default!;
+    [Dependency] private readonly ActionBlockerSystem _actionBlocker = default!;
 
     private int _nextId = 1;
 
@@ -24,6 +31,45 @@ public sealed class MedievalIdentitySystem : SharedMedievalIdentitySystem
 
         SubscribeLocalEvent<IdentityRequiresKnowledgeComponent, ComponentInit>(OnComponentInit, before: new[] { typeof(SharedMedievalFactionsSystem) });
         SubscribeLocalEvent<IdentityRequiresKnowledgeComponent, PlayerAttachedEvent>(OnPlayerAttached);
+        SubscribeNetworkEvent<MedievalIntroduceIdentityRequest>(OnIntroduceIdentity);
+    }
+
+    private void OnIntroduceIdentity(MedievalIntroduceIdentityRequest request, EntitySessionEventArgs args)
+    {
+        if (args.SenderSession.AttachedEntity is not { } introducer ||
+            !TryGetEntity(request.Observer, out var observer))
+        {
+            return;
+        }
+
+        Introduce(introducer, observer.Value);
+    }
+
+    public bool Introduce(EntityUid introducer, EntityUid observer)
+    {
+        if (!_actionBlocker.CanInteract(introducer, observer) ||
+            !_interaction.InRangeAndAccessible(introducer, observer) ||
+            !TryComp<IdentityRequiresKnowledgeComponent>(observer, out var observerComp) ||
+            !CanIntroduce(introducer, observer, observerComp) ||
+            !TryComp<IdentityRequiresKnowledgeComponent>(introducer, out var introducerComp))
+        {
+            return false;
+        }
+
+        observerComp.KnownIds.Add(introducerComp.Identifier);
+        Dirty(observer, observerComp);
+
+        var introducerName = Identity.Name(introducer, EntityManager, introducer);
+        _popup.PopupEntity(
+            Loc.GetString("imperial-hm-identity-introduce", ("name", introducerName)),
+            introducer,
+            introducer);
+        _popup.PopupEntity(
+            Loc.GetString("imperial-hm-identity-introduction", ("name", introducerName)),
+            introducer,
+            observer);
+
+        return true;
     }
 
     private void OnComponentInit(EntityUid uid, IdentityRequiresKnowledgeComponent component, ComponentInit args)

--- a/Content.Shared/Imperial/Medieval/Identity/SharedMedievalIdentitySystem.cs
+++ b/Content.Shared/Imperial/Medieval/Identity/SharedMedievalIdentitySystem.cs
@@ -1,16 +1,14 @@
 using Content.Shared.Examine;
 using Content.Shared.IdentityManagement;
 using Content.Shared.IdentityManagement.Components;
-using Content.Shared.Popups;
 using Content.Shared.Verbs;
+using Robust.Shared.Serialization;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Imperial.Medieval.IdentityManagement;
 
 public abstract class SharedMedievalIdentitySystem : EntitySystem
 {
-    [Dependency] private readonly SharedPopupSystem _popup = default!;
-
     public override void Initialize()
     {
         base.Initialize();
@@ -22,36 +20,54 @@ public abstract class SharedMedievalIdentitySystem : EntitySystem
 
     private void OnGetVerbs(EntityUid uid, IdentityRequiresKnowledgeComponent component, GetVerbsEvent<AlternativeVerb> args)
     {
-        if (!TryComp<IdentityRequiresKnowledgeComponent>(args.User, out var userComp))
-            return;
-        if (uid == args.User)
-            return;
-        if (component.KnownIds.Contains(userComp.Identifier) || !userComp.HideUnknown)
+        if (!args.CanInteract ||
+            !args.CanAccess ||
+            !CanIntroduce(args.User, uid, component))
             return;
 
         args.Verbs.Add(new AlternativeVerb()
         {
             Act = () =>
             {
-                _popup.PopupPredicted($"Вы представились {Identity.Name(uid, EntityManager, args.User)}.", null, uid, args.User);
-                _popup.PopupPredicted($"{Name(args.User)} представился вам.", null, args.User, uid);
-                component.KnownIds.Add(userComp.Identifier);
-                Dirty(uid, component);
+                RaiseNetworkEvent(new MedievalIntroduceIdentityRequest(GetNetEntity(uid)));
             },
             Icon = new SpriteSpecifier.Rsi(new ResPath("/Textures/Imperial/Medieval/date.rsi"), "date"),
             Priority = 1,
-            Text = "Представиться"
+            Text = Loc.GetString("imperial-hm-identity-intrd")
         });
+    }
+
+    public bool CanIntroduce(EntityUid introducer, EntityUid observer, IdentityRequiresKnowledgeComponent? observerComp = null)
+    {
+        if (introducer == observer ||
+            !Resolve(observer, ref observerComp, false) ||
+            !TryComp<IdentityRequiresKnowledgeComponent>(introducer, out var introducerComp))
+        {
+            return false;
+        }
+
+        return introducerComp.HideUnknown && !observerComp.KnownIds.Contains(introducerComp.Identifier);
     }
 
     private void OnExamined(EntityUid uid, IdentityRequiresKnowledgeComponent component, ExaminedEvent args)
     {
-        args.PushMarkup($"[font=Default size=8][color=gray]Идентификатор игрока:[/color] {component.Identifier}[/font]", -1);
+        args.PushMarkup(Loc.GetString("imperial-hm-identity-id", ("name", component.Identifier)), -1);
     }
     public bool IsIdentityMasked(EntityUid entity)
     {
         var ev = new SeeIdentityAttemptEvent();
         RaiseLocalEvent(entity, ev);
         return ev.Cancelled;  // Если отменено, то идентичность заблокирована (маска или полный coverage)
+    }
+}
+
+[Serializable, NetSerializable]
+public sealed class MedievalIntroduceIdentityRequest : EntityEventArgs
+{
+    public NetEntity Observer { get; set; }
+
+    public MedievalIntroduceIdentityRequest(NetEntity observer)
+    {
+        Observer = observer;
     }
 }

--- a/Resources/Locale/ru-RU/Imperial/Medieval/HamMaggotson/Identity/identity.ftl
+++ b/Resources/Locale/ru-RU/Imperial/Medieval/HamMaggotson/Identity/identity.ftl
@@ -1,0 +1,4 @@
+imperial-hm-identity-introduce = Вы представились как {$name}.
+imperial-hm-identity-introduction = {$name} представился вам.
+imperial-hm-identity-id = [font=Default size=8][color=gray]Идентификатор игрока:[/color] {$name}[/font]
+imperial-hm-identity-intrd = Представиться


### PR DESCRIPTION
## Summary
- make medieval introductions authoritative on the server and synchronize identity knowledge
- reject introduction requests when the observer is out of interaction range or inaccessible
- add Russian localization and client/server integration coverage

## Validation
- `dotnet build Content.IntegrationTests/Content.IntegrationTests.csproj --no-restore`: 0 errors
- `IntroductionVerbSynchronizesThroughNetworkRequest`: passed independently
- `IntroductionSynchronizesDirectionalIdentityKnowledge`: passed independently
- `git diff --check develop...HEAD`: passed