### PR TITLE
Fix grimoire recall item placement

### DIFF
--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -54,10 +54,12 @@ public sealed class SummonFoliantTest
             var player = playerMan.Sessions.First().AttachedEntity!.Value;
             var hands = entMan.GetComponent<HandsComponent>(player);
             var heldItems = new List<EntityUid>();
+            var heldPrototypes = new[] { "MedievalCommsCrystallColl", "MedievalKeyWizard" };
 
-            for (var i = 0; i < hands.Count; i++)
+            Assert.That(hands.Count, Is.EqualTo(heldPrototypes.Length));
+            foreach (var prototype in heldPrototypes)
             {
-                var held = entMan.SpawnEntity("Crowbar", map.GridCoords);
+                var held = entMan.SpawnEntity(prototype, map.GridCoords);
                 Assert.That(handsSystem.TryPickupAnyHand(player, held), Is.True);
                 heldItems.Add(held);
             }

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -9,8 +9,6 @@ using Content.Shared.Imperial.Medieval.Magic;
 using Content.Shared.Inventory;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
-using Content.Shared.Storage;
-using Content.Shared.Storage.EntitySystems;
 using Robust.Server.Player;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Collections.Generic;
 using Content.Server.Imperial.Medieval.Magic.BindStoreOnEquip;
+using Content.Server.Imperial.Medieval.Magic.MedievalSpawnInFreeSlot;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Imperial.Medieval.Magic;
@@ -46,6 +47,7 @@ public sealed class SummonFoliantTest
         var handsSystem = server.System<SharedHandsSystem>();
         var containerSystem = server.System<SharedContainerSystem>();
         var inventorySystem = server.System<InventorySystem>();
+        var placementSystem = server.System<MedievalSpawnInFreeSlotSystem>();
 
         await server.WaitAssertion(() =>
         {
@@ -97,6 +99,15 @@ public sealed class SummonFoliantTest
             var heldWithFoliant = handsSystem.EnumerateHeld((player, hands)).ToList();
             entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
             Assert.That(handsSystem.EnumerateHeld((player, hands)).ToList(), Is.EquivalentTo(heldWithFoliant));
+
+            var directlyPlacedItem = entMan.SpawnEntity("Crowbar", map.GridCoords);
+            Assert.That(placementSystem.TryPlaceInFreeSlot(player, directlyPlacedItem), Is.True);
+            Assert.That(containerSystem.TryGetContainingContainer(directlyPlacedItem, out var directContainer), Is.True);
+            Assert.That(inventorySystem.GetHandOrInventoryEntities(player), Does.Contain(directContainer.Owner));
+
+            Assert.That(placementSystem.TryPlaceInFreeSlot(player, directlyPlacedItem), Is.True);
+            Assert.That(containerSystem.TryGetContainingContainer(directlyPlacedItem, out var unchangedContainer), Is.True);
+            Assert.That(unchangedContainer.Owner, Is.EqualTo(directContainer.Owner));
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -16,6 +16,7 @@ using Robust.Shared.GameObjects;
 namespace Content.IntegrationTests.Tests.Imperial.Medieval.Magic;
 
 [TestFixture]
+[NonParallelizable]
 public sealed class SummonFoliantTest
 {
     [TestPrototypes]
@@ -154,6 +155,10 @@ public sealed class SummonFoliantTest
         {
             var player = playerMan.Sessions.First().AttachedEntity!.Value;
             var hands = entMan.GetComponent<HandsComponent>(player);
+
+            foreach (var held in handsSystem.EnumerateHeld((player, hands)).ToList())
+                Assert.That(handsSystem.TryDrop(player, held), Is.True);
+
             Assert.That(handsSystem.CountFreeHands((player, hands)), Is.EqualTo(hands.Count));
 
             var key = entMan.SpawnEntity("MedievalKeyWizard", map.GridCoords);

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using System.Collections.Generic;
+using Content.Server.Imperial.Medieval.Magic.BindStoreOnEquip;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Imperial.Medieval.Magic;
+using Robust.Server.Player;
+using Robust.Shared.Containers;
+using Robust.Shared.GameObjects;
+
+namespace Content.IntegrationTests.Tests.Imperial.Medieval.Magic;
+
+[TestFixture]
+public sealed class SummonFoliantTest
+{
+    [TestPrototypes]
+    private const string Prototypes = @"
+- type: entity
+  id: TestSummonFoliantPouch
+  components:
+  - type: ContainerContainer
+    containers:
+      pouch: !type:Container
+
+- type: entity
+  id: TestSummonFoliantProjectile
+  components:
+  - type: FoliantToHandTeleporter
+";
+
+    [Test]
+    public async Task SummonDoesNotDisplaceHeldItems()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            DummyTicker = false
+        });
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+        await pair.RunTicksSync(5);
+
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var playerMan = server.ResolveDependency<IPlayerManager>();
+        var handsSystem = server.System<SharedHandsSystem>();
+        var containerSystem = server.System<SharedContainerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var player = playerMan.Sessions.First().AttachedEntity!.Value;
+            var hands = entMan.GetComponent<HandsComponent>(player);
+            var heldItems = new List<EntityUid>();
+
+            for (var i = 0; i < hands.Count; i++)
+            {
+                var held = entMan.SpawnEntity("Crowbar", map.GridCoords);
+                Assert.That(handsSystem.TryPickupAnyHand(player, held), Is.True);
+                heldItems.Add(held);
+            }
+
+            var pouch = entMan.SpawnEntity("TestSummonFoliantPouch", map.GridCoords);
+            var foliant = entMan.SpawnEntity("Crowbar", map.GridCoords);
+            var bind = entMan.EnsureComponent<BindStoreOnEquipComponent>(foliant);
+#pragma warning disable RA0002
+            bind.BindedEntity = player;
+#pragma warning restore RA0002
+            Assert.That(containerSystem.TryGetContainer(pouch, "pouch", out var container), Is.True);
+            Assert.That(containerSystem.Insert(foliant, container), Is.True);
+
+            var projectile = entMan.SpawnEntity("TestSummonFoliantProjectile", map.GridCoords);
+            var spellEvent = new MedievalAfterSpawnEntityBySpellEvent
+            {
+                Performer = player,
+                SpawnedEntity = projectile
+            };
+            entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
+
+            Assert.That(handsSystem.EnumerateHeld((player, hands)).ToList(), Is.EquivalentTo(heldItems));
+            Assert.That(container.Contains(foliant), Is.True);
+
+            Assert.That(handsSystem.TryDrop(player, heldItems[0]), Is.True);
+            entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
+
+            Assert.That(handsSystem.IsHolding(player, foliant), Is.True);
+            Assert.That(container.Contains(foliant), Is.False);
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -78,8 +78,8 @@ public sealed class SummonFoliantTest
             }
 
             var pouch = entMan.SpawnEntity("TestSummonFoliantPouch", map.GridCoords);
-            var foliant = entMan.SpawnEntity("Crowbar", map.GridCoords);
-            var bind = entMan.EnsureComponent<BindStoreOnEquipComponent>(foliant);
+            var foliant = entMan.SpawnEntity("MedievalSpellBookBase", map.GridCoords);
+            var bind = entMan.GetComponent<BindStoreOnEquipComponent>(foliant);
 #pragma warning disable RA0002
             bind.BindedEntity = player;
 #pragma warning restore RA0002
@@ -163,8 +163,8 @@ public sealed class SummonFoliantTest
             var carriedStorage = inventorySystem.GetHandOrInventoryEntities(player)
                 .First(entity => entMan.HasComponent<StorageComponent>(entity));
             var crystal = entMan.SpawnEntity("MedievalCommsCrystallColl", map.GridCoords);
-            var foliant = entMan.SpawnEntity("Crowbar", map.GridCoords);
-            var bind = entMan.EnsureComponent<BindStoreOnEquipComponent>(foliant);
+            var foliant = entMan.SpawnEntity("MedievalSpellBookBase", map.GridCoords);
+            var bind = entMan.GetComponent<BindStoreOnEquipComponent>(foliant);
 #pragma warning disable RA0002
             bind.BindedEntity = player;
 #pragma warning restore RA0002

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -4,6 +4,7 @@ using Content.Server.Imperial.Medieval.Magic.BindStoreOnEquip;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Imperial.Medieval.Magic;
+using Content.Shared.Inventory;
 using Robust.Server.Player;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
@@ -44,6 +45,7 @@ public sealed class SummonFoliantTest
         var playerMan = server.ResolveDependency<IPlayerManager>();
         var handsSystem = server.System<SharedHandsSystem>();
         var containerSystem = server.System<SharedContainerSystem>();
+        var inventorySystem = server.System<InventorySystem>();
 
         await server.WaitAssertion(() =>
         {
@@ -76,13 +78,25 @@ public sealed class SummonFoliantTest
             entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
 
             Assert.That(handsSystem.EnumerateHeld((player, hands)).ToList(), Is.EquivalentTo(heldItems));
-            Assert.That(container.Contains(foliant), Is.True);
+            Assert.That(container.Contains(foliant), Is.False);
+            Assert.That(containerSystem.TryGetContainingContainer(foliant, out var carriedContainer), Is.True);
+            Assert.That(inventorySystem.GetHandOrInventoryEntities(player), Does.Contain(carriedContainer.Owner));
+
+            entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
+            Assert.That(containerSystem.TryGetContainingContainer(foliant, out var sameContainer), Is.True);
+            Assert.That(sameContainer.Owner, Is.EqualTo(carriedContainer.Owner));
+
+            Assert.That(containerSystem.Insert(foliant, container), Is.True);
 
             Assert.That(handsSystem.TryDrop(player, heldItems[0]), Is.True);
             entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
 
             Assert.That(handsSystem.IsHolding(player, foliant), Is.True);
             Assert.That(container.Contains(foliant), Is.False);
+
+            var heldWithFoliant = handsSystem.EnumerateHeld((player, hands)).ToList();
+            entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
+            Assert.That(handsSystem.EnumerateHeld((player, hands)).ToList(), Is.EquivalentTo(heldWithFoliant));
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -6,6 +6,8 @@ using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Imperial.Medieval.Magic;
 using Content.Shared.Inventory;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
 using Robust.Server.Player;
 using Robust.Shared.Containers;
 using Robust.Shared.GameObjects;
@@ -28,6 +30,15 @@ public sealed class SummonFoliantTest
   id: TestSummonFoliantProjectile
   components:
   - type: FoliantToHandTeleporter
+
+- type: entity
+  id: TestSummonFoliantNestedContainer
+  components:
+  - type: Item
+    size: Tiny
+  - type: ContainerContainer
+    containers:
+      nested: !type:Container
 ";
 
     [Test]
@@ -48,6 +59,7 @@ public sealed class SummonFoliantTest
         var containerSystem = server.System<SharedContainerSystem>();
         var inventorySystem = server.System<InventorySystem>();
         var placementSystem = server.System<MedievalSpawnInFreeSlotSystem>();
+        var storageSystem = server.System<SharedStorageSystem>();
 
         await server.WaitAssertion(() =>
         {
@@ -110,6 +122,40 @@ public sealed class SummonFoliantTest
             Assert.That(placementSystem.TryPlaceInFreeSlot(player, directlyPlacedItem), Is.True);
             Assert.That(containerSystem.TryGetContainingContainer(directlyPlacedItem, out var unchangedContainer), Is.True);
             Assert.That(unchangedContainer.Owner, Is.EqualTo(directContainer.Owner));
+
+            // An item nested inside carried storage is already safely carried and must not move.
+            var nestedContainer = entMan.SpawnEntity("TestSummonFoliantNestedContainer", map.GridCoords);
+            Assert.That(storageSystem.Insert(directContainer.Owner, nestedContainer, out _, playSound: false), Is.True);
+            Assert.That(containerSystem.TryGetContainer(nestedContainer, "nested", out var nested), Is.True);
+            var nestedItem = entMan.SpawnEntity("Crowbar", map.GridCoords);
+            Assert.That(containerSystem.Insert(nestedItem, nested), Is.True);
+
+            Assert.That(placementSystem.TryPlaceInFreeSlot(player, nestedItem), Is.True);
+            Assert.That(containerSystem.TryGetContainingContainer(nestedItem, out var unchangedNested), Is.True);
+            Assert.That(unchangedNested.Owner, Is.EqualTo(nestedContainer));
+
+            // A non-item cannot be picked up or inserted into carried storage. Failure must leave it untouched.
+            var rejectedContainerOwner = entMan.SpawnEntity("TestSummonFoliantPouch", map.GridCoords);
+            var rejectedItem = entMan.SpawnEntity("TestSummonFoliantPouch", map.GridCoords);
+            Assert.That(containerSystem.TryGetContainer(rejectedContainerOwner, "pouch", out var rejectedContainer), Is.True);
+            Assert.That(containerSystem.Insert(rejectedItem, rejectedContainer), Is.True);
+
+            Assert.That(placementSystem.TryPlaceInFreeSlot(player, rejectedItem), Is.False);
+            Assert.That(rejectedContainer.Contains(rejectedItem), Is.True);
+            Assert.That(entMan.EntityExists(rejectedItem), Is.True);
+
+            // With full hands and no compatible carried storage, a normal item must also remain where it was.
+            foreach (var carried in inventorySystem.GetHandOrInventoryEntities(player).ToList())
+                entMan.RemoveComponent<StorageComponent>(carried);
+
+            var strandedContainerOwner = entMan.SpawnEntity("TestSummonFoliantPouch", map.GridCoords);
+            var strandedItem = entMan.SpawnEntity("Crowbar", map.GridCoords);
+            Assert.That(containerSystem.TryGetContainer(strandedContainerOwner, "pouch", out var strandedContainer), Is.True);
+            Assert.That(containerSystem.Insert(strandedItem, strandedContainer), Is.True);
+
+            Assert.That(placementSystem.TryPlaceInFreeSlot(player, strandedItem), Is.False);
+            Assert.That(strandedContainer.Contains(strandedItem), Is.True);
+            Assert.That(entMan.EntityExists(strandedItem), Is.True);
         });
 
         await pair.CleanReturnAsync();

--- a/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
+++ b/Content.IntegrationTests/Tests/Imperial/Medieval/Magic/SummonFoliantTest.cs
@@ -2,10 +2,13 @@ using System.Linq;
 using System.Collections.Generic;
 using Content.Server.Imperial.Medieval.Magic.BindStoreOnEquip;
 using Content.Server.Imperial.Medieval.Magic.MedievalSpawnInFreeSlot;
+using Content.Shared.Actions;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Imperial.Medieval.Magic;
 using Content.Shared.Inventory;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Server.Player;
@@ -66,9 +69,9 @@ public sealed class SummonFoliantTest
             var player = playerMan.Sessions.First().AttachedEntity!.Value;
             var hands = entMan.GetComponent<HandsComponent>(player);
             var heldItems = new List<EntityUid>();
-            var heldPrototypes = new[] { "MedievalCommsCrystallColl", "MedievalKeyWizard" };
+            var heldPrototypes = new[] { "MedievalCommsCrystallColl" };
 
-            Assert.That(hands.Count, Is.EqualTo(heldPrototypes.Length));
+            Assert.That(hands.Count, Is.GreaterThan(heldPrototypes.Length));
             foreach (var prototype in heldPrototypes)
             {
                 var held = entMan.SpawnEntity(prototype, map.GridCoords);
@@ -93,39 +96,19 @@ public sealed class SummonFoliantTest
             };
             entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
 
-            Assert.That(handsSystem.EnumerateHeld((player, hands)).ToList(), Is.EquivalentTo(heldItems));
-            Assert.That(container.Contains(foliant), Is.False);
-            Assert.That(containerSystem.TryGetContainingContainer(foliant, out var carriedContainer), Is.True);
-            Assert.That(inventorySystem.GetHandOrInventoryEntities(player), Does.Contain(carriedContainer.Owner));
-
-            entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
-            Assert.That(containerSystem.TryGetContainingContainer(foliant, out var sameContainer), Is.True);
-            Assert.That(sameContainer.Owner, Is.EqualTo(carriedContainer.Owner));
-
-            Assert.That(containerSystem.Insert(foliant, container), Is.True);
-
-            Assert.That(handsSystem.TryDrop(player, heldItems[0]), Is.True);
-            entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
-
+            Assert.That(handsSystem.IsHolding(player, heldItems[0]), Is.True);
             Assert.That(handsSystem.IsHolding(player, foliant), Is.True);
             Assert.That(container.Contains(foliant), Is.False);
 
-            var heldWithFoliant = handsSystem.EnumerateHeld((player, hands)).ToList();
             entMan.EventBus.RaiseLocalEvent(projectile, spellEvent);
-            Assert.That(handsSystem.EnumerateHeld((player, hands)).ToList(), Is.EquivalentTo(heldWithFoliant));
-
-            var directlyPlacedItem = entMan.SpawnEntity("Crowbar", map.GridCoords);
-            Assert.That(placementSystem.TryPlaceInFreeSlot(player, directlyPlacedItem), Is.True);
-            Assert.That(containerSystem.TryGetContainingContainer(directlyPlacedItem, out var directContainer), Is.True);
-            Assert.That(inventorySystem.GetHandOrInventoryEntities(player), Does.Contain(directContainer.Owner));
-
-            Assert.That(placementSystem.TryPlaceInFreeSlot(player, directlyPlacedItem), Is.True);
-            Assert.That(containerSystem.TryGetContainingContainer(directlyPlacedItem, out var unchangedContainer), Is.True);
-            Assert.That(unchangedContainer.Owner, Is.EqualTo(directContainer.Owner));
+            Assert.That(handsSystem.IsHolding(player, heldItems[0]), Is.True);
+            Assert.That(handsSystem.IsHolding(player, foliant), Is.True);
 
             // An item nested inside carried storage is already safely carried and must not move.
+            var carriedStorage = inventorySystem.GetHandOrInventoryEntities(player)
+                .First(carried => entMan.HasComponent<StorageComponent>(carried));
             var nestedContainer = entMan.SpawnEntity("TestSummonFoliantNestedContainer", map.GridCoords);
-            Assert.That(storageSystem.Insert(directContainer.Owner, nestedContainer, out _, playSound: false), Is.True);
+            Assert.That(storageSystem.Insert(carriedStorage, nestedContainer, out _, playSound: false), Is.True);
             Assert.That(containerSystem.TryGetContainer(nestedContainer, "nested", out var nested), Is.True);
             var nestedItem = entMan.SpawnEntity("Crowbar", map.GridCoords);
             Assert.That(containerSystem.Insert(nestedItem, nested), Is.True);
@@ -135,6 +118,7 @@ public sealed class SummonFoliantTest
             Assert.That(unchangedNested.Owner, Is.EqualTo(nestedContainer));
 
             // A non-item cannot be picked up or inserted into carried storage. Failure must leave it untouched.
+            Assert.That(handsSystem.TryDrop(player, foliant), Is.True);
             var rejectedContainerOwner = entMan.SpawnEntity("TestSummonFoliantPouch", map.GridCoords);
             var rejectedItem = entMan.SpawnEntity("TestSummonFoliantPouch", map.GridCoords);
             Assert.That(containerSystem.TryGetContainer(rejectedContainerOwner, "pouch", out var rejectedContainer), Is.True);
@@ -143,19 +127,67 @@ public sealed class SummonFoliantTest
             Assert.That(placementSystem.TryPlaceInFreeSlot(player, rejectedItem), Is.False);
             Assert.That(rejectedContainer.Contains(rejectedItem), Is.True);
             Assert.That(entMan.EntityExists(rejectedItem), Is.True);
+        });
 
-            // With full hands and no compatible carried storage, a normal item must also remain where it was.
-            foreach (var carried in inventorySystem.GetHandOrInventoryEntities(player).ToList())
-                entMan.RemoveComponent<StorageComponent>(carried);
+        await pair.CleanReturnAsync();
+    }
 
-            var strandedContainerOwner = entMan.SpawnEntity("TestSummonFoliantPouch", map.GridCoords);
-            var strandedItem = entMan.SpawnEntity("Crowbar", map.GridCoords);
-            Assert.That(containerSystem.TryGetContainer(strandedContainerOwner, "pouch", out var strandedContainer), Is.True);
-            Assert.That(containerSystem.Insert(strandedItem, strandedContainer), Is.True);
+    [Test]
+    public async Task SummonThroughActionKeepsWizardItemsInPlace()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Connected = true,
+            DummyTicker = false
+        });
+        var server = pair.Server;
+        var map = await pair.CreateTestMap();
+        await pair.RunTicksSync(5);
 
-            Assert.That(placementSystem.TryPlaceInFreeSlot(player, strandedItem), Is.False);
-            Assert.That(strandedContainer.Contains(strandedItem), Is.True);
-            Assert.That(entMan.EntityExists(strandedItem), Is.True);
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var playerMan = server.ResolveDependency<IPlayerManager>();
+        var actionsSystem = server.System<SharedActionsSystem>();
+        var handsSystem = server.System<SharedHandsSystem>();
+        var inventorySystem = server.System<InventorySystem>();
+        var storageSystem = server.System<SharedStorageSystem>();
+        var containerSystem = server.System<SharedContainerSystem>();
+
+        await server.WaitAssertion(() =>
+        {
+            var player = playerMan.Sessions.First().AttachedEntity!.Value;
+            var hands = entMan.GetComponent<HandsComponent>(player);
+            Assert.That(handsSystem.CountFreeHands((player, hands)), Is.EqualTo(hands.Count));
+
+            var key = entMan.SpawnEntity("MedievalKeyWizard", map.GridCoords);
+            Assert.That(handsSystem.TryPickupAnyHand(player, key), Is.True);
+            Assert.That(handsSystem.CountFreeHands((player, hands)), Is.EqualTo(hands.Count - 1));
+
+            var carriedStorage = inventorySystem.GetHandOrInventoryEntities(player)
+                .First(entity => entMan.HasComponent<StorageComponent>(entity));
+            var crystal = entMan.SpawnEntity("MedievalCommsCrystallColl", map.GridCoords);
+            var foliant = entMan.SpawnEntity("Crowbar", map.GridCoords);
+            var bind = entMan.EnsureComponent<BindStoreOnEquipComponent>(foliant);
+#pragma warning disable RA0002
+            bind.BindedEntity = player;
+#pragma warning restore RA0002
+
+            Assert.That(storageSystem.Insert(carriedStorage, crystal, out _), Is.True);
+            Assert.That(storageSystem.Insert(carriedStorage, foliant, out _), Is.True);
+            Assert.That(containerSystem.TryGetContainingContainer(foliant, out var originalContainer), Is.True);
+
+            var actionUid = actionsSystem.AddAction(player, "MedievalActionSummonFoliantBeginner");
+            Assert.That(actionUid, Is.Not.Null);
+            var action = actionsSystem.GetAction(actionUid);
+            Assert.That(action, Is.Not.Null);
+
+            actionsSystem.PerformAction(player, action.Value);
+
+            Assert.That(action.Value.Comp.Cooldown, Is.Not.Null);
+            Assert.That(handsSystem.IsHolding(player, key), Is.True);
+            Assert.That(containerSystem.TryGetContainingContainer(crystal, out var crystalContainer), Is.True);
+            Assert.That(containerSystem.TryGetContainingContainer(foliant, out var resultingContainer), Is.True);
+            Assert.That(crystalContainer.Owner, Is.EqualTo(carriedStorage));
+            Assert.That(resultingContainer.Owner, Is.EqualTo(originalContainer.Owner));
         });
 
         await pair.CleanReturnAsync();

--- a/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalFoliantToHandTeleporter/FoliantToHandTeleporterSystem.cs
+++ b/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalFoliantToHandTeleporter/FoliantToHandTeleporterSystem.cs
@@ -22,7 +22,7 @@ public sealed partial class FoliantToHandTeleporterSystem : EntitySystem
         {
             if (bindComp.BindedEntity == playerUid)
             {
-                _handsSystem.TryForcePickupAnyHand(playerUid, folliantUID);
+                _handsSystem.TryPickupAnyHand(playerUid, folliantUID);
                 break;
             }
         }

--- a/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalFoliantToHandTeleporter/FoliantToHandTeleporterSystem.cs
+++ b/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalFoliantToHandTeleporter/FoliantToHandTeleporterSystem.cs
@@ -1,11 +1,19 @@
+using System.Linq;
 using Content.Server.Imperial.Medieval.Magic.BindStoreOnEquip;
 using Content.Shared.Imperial.Medieval.Magic;
 using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Inventory;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Containers;
 
 namespace Content.Server.Imperial.Medieval.Magic.MedievalFoliantToHandTeleporter;
 public sealed partial class FoliantToHandTeleporterSystem : EntitySystem
 {
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
+    [Dependency] private readonly SharedStorageSystem _storageSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
 
     public override void Initialize()
     {
@@ -22,9 +30,40 @@ public sealed partial class FoliantToHandTeleporterSystem : EntitySystem
         {
             if (bindComp.BindedEntity == playerUid)
             {
-                _handsSystem.TryPickupAnyHand(playerUid, folliantUID);
+                TryMoveToCarriedSlot(playerUid, folliantUID);
                 break;
             }
+        }
+    }
+
+    private void TryMoveToCarriedSlot(EntityUid playerUid, EntityUid foliantUid)
+    {
+        var carriedEntities = _inventorySystem.GetHandOrInventoryEntities(playerUid).ToList();
+
+        // If the foliant is already in a hand, inventory slot, or carried storage,
+        // leave it exactly where it is.
+        if (carriedEntities.Contains(foliantUid))
+            return;
+
+        var current = foliantUid;
+        while (_containerSystem.TryGetContainingContainer(current, out var container))
+        {
+            if (carriedEntities.Contains(container.Owner))
+                return;
+
+            current = container.Owner;
+        }
+
+        if (_handsSystem.TryPickupAnyHand(playerUid, foliantUid))
+            return;
+
+        foreach (var carried in carriedEntities)
+        {
+            if (carried == foliantUid || !TryComp<StorageComponent>(carried, out var storage))
+                continue;
+
+            if (_storageSystem.Insert(carried, foliantUid, out _, storageComp: storage, playSound: false))
+                return;
         }
     }
 }

--- a/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalFoliantToHandTeleporter/FoliantToHandTeleporterSystem.cs
+++ b/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalFoliantToHandTeleporter/FoliantToHandTeleporterSystem.cs
@@ -1,19 +1,11 @@
-using System.Linq;
 using Content.Server.Imperial.Medieval.Magic.BindStoreOnEquip;
+using Content.Server.Imperial.Medieval.Magic.MedievalSpawnInFreeHandOrPouch;
 using Content.Shared.Imperial.Medieval.Magic;
-using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Inventory;
-using Content.Shared.Storage;
-using Content.Shared.Storage.EntitySystems;
-using Robust.Shared.Containers;
 
 namespace Content.Server.Imperial.Medieval.Magic.MedievalFoliantToHandTeleporter;
 public sealed partial class FoliantToHandTeleporterSystem : EntitySystem
 {
-    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
-    [Dependency] private readonly InventorySystem _inventorySystem = default!;
-    [Dependency] private readonly SharedStorageSystem _storageSystem = default!;
-    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+    [Dependency] private readonly MedievalSpawnInFreeHandOrPouchSystem _placementSystem = default!;
 
     public override void Initialize()
     {
@@ -30,40 +22,9 @@ public sealed partial class FoliantToHandTeleporterSystem : EntitySystem
         {
             if (bindComp.BindedEntity == playerUid)
             {
-                TryMoveToCarriedSlot(playerUid, folliantUID);
+                _placementSystem.TryPlaceInFreeHandOrPouch(playerUid, folliantUID);
                 break;
             }
-        }
-    }
-
-    private void TryMoveToCarriedSlot(EntityUid playerUid, EntityUid foliantUid)
-    {
-        var carriedEntities = _inventorySystem.GetHandOrInventoryEntities(playerUid).ToList();
-
-        // If the foliant is already in a hand, inventory slot, or carried storage,
-        // leave it exactly where it is.
-        if (carriedEntities.Contains(foliantUid))
-            return;
-
-        var current = foliantUid;
-        while (_containerSystem.TryGetContainingContainer(current, out var container))
-        {
-            if (carriedEntities.Contains(container.Owner))
-                return;
-
-            current = container.Owner;
-        }
-
-        if (_handsSystem.TryPickupAnyHand(playerUid, foliantUid))
-            return;
-
-        foreach (var carried in carriedEntities)
-        {
-            if (carried == foliantUid || !TryComp<StorageComponent>(carried, out var storage))
-                continue;
-
-            if (_storageSystem.Insert(carried, foliantUid, out _, storageComp: storage, playSound: false))
-                return;
         }
     }
 }

--- a/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalFoliantToHandTeleporter/FoliantToHandTeleporterSystem.cs
+++ b/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalFoliantToHandTeleporter/FoliantToHandTeleporterSystem.cs
@@ -1,11 +1,12 @@
 using Content.Server.Imperial.Medieval.Magic.BindStoreOnEquip;
-using Content.Server.Imperial.Medieval.Magic.MedievalSpawnInFreeHandOrPouch;
+using Content.Server.Imperial.Medieval.Magic.MedievalSpawnInFreeSlot;
 using Content.Shared.Imperial.Medieval.Magic;
 
 namespace Content.Server.Imperial.Medieval.Magic.MedievalFoliantToHandTeleporter;
+
 public sealed partial class FoliantToHandTeleporterSystem : EntitySystem
 {
-    [Dependency] private readonly MedievalSpawnInFreeHandOrPouchSystem _placementSystem = default!;
+    [Dependency] private readonly MedievalSpawnInFreeSlotSystem _placementSystem = default!;
 
     public override void Initialize()
     {
@@ -22,7 +23,7 @@ public sealed partial class FoliantToHandTeleporterSystem : EntitySystem
         {
             if (bindComp.BindedEntity == playerUid)
             {
-                _placementSystem.TryPlaceInFreeHandOrPouch(playerUid, folliantUID);
+                _placementSystem.TryPlaceInFreeSlot(playerUid, folliantUID);
                 break;
             }
         }

--- a/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalSpawnInFreeHandOrPouch/MedievalSpawnInFreeHandOrPouchSystem.cs
+++ b/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalSpawnInFreeHandOrPouch/MedievalSpawnInFreeHandOrPouchSystem.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Inventory;
+using Content.Shared.Storage;
+using Content.Shared.Storage.EntitySystems;
+using Robust.Shared.Containers;
+
+namespace Content.Server.Imperial.Medieval.Magic.MedievalSpawnInFreeHandOrPouch;
+
+/// <summary>
+/// Places an item in a safe carried destination without displacing other items.
+/// Already carried items stay in their current hand, inventory slot, or storage.
+/// </summary>
+public sealed class MedievalSpawnInFreeHandOrPouchSystem : EntitySystem
+{
+    [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+    [Dependency] private readonly InventorySystem _inventorySystem = default!;
+    [Dependency] private readonly SharedStorageSystem _storageSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+
+    public bool TryPlaceInFreeHandOrPouch(EntityUid playerUid, EntityUid itemUid)
+    {
+        var carriedEntities = _inventorySystem.GetHandOrInventoryEntities(playerUid).ToList();
+
+        if (carriedEntities.Contains(itemUid))
+            return true;
+
+        var current = itemUid;
+        while (_containerSystem.TryGetContainingContainer(current, out var container))
+        {
+            if (carriedEntities.Contains(container.Owner))
+                return true;
+
+            current = container.Owner;
+        }
+
+        if (_handsSystem.TryPickupAnyHand(playerUid, itemUid))
+            return true;
+
+        foreach (var carried in carriedEntities)
+        {
+            if (carried == itemUid || !TryComp<StorageComponent>(carried, out var storage))
+                continue;
+
+            if (_storageSystem.Insert(carried, itemUid, out _, storageComp: storage, playSound: false))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalSpawnInFreeSlot/MedievalSpawnInFreeSlotSystem.cs
+++ b/Content.Server/Imperial/Medieval/Magic/Other/Spells/MedievalSpawnInFreeSlot/MedievalSpawnInFreeSlotSystem.cs
@@ -5,20 +5,20 @@ using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
 using Robust.Shared.Containers;
 
-namespace Content.Server.Imperial.Medieval.Magic.MedievalSpawnInFreeHandOrPouch;
+namespace Content.Server.Imperial.Medieval.Magic.MedievalSpawnInFreeSlot;
 
 /// <summary>
-/// Places an item in a safe carried destination without displacing other items.
+/// Places an item in a free carried slot without displacing other items.
 /// Already carried items stay in their current hand, inventory slot, or storage.
 /// </summary>
-public sealed class MedievalSpawnInFreeHandOrPouchSystem : EntitySystem
+public sealed class MedievalSpawnInFreeSlotSystem : EntitySystem
 {
     [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] private readonly InventorySystem _inventorySystem = default!;
     [Dependency] private readonly SharedStorageSystem _storageSystem = default!;
     [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
 
-    public bool TryPlaceInFreeHandOrPouch(EntityUid playerUid, EntityUid itemUid)
+    public bool TryPlaceInFreeSlot(EntityUid playerUid, EntityUid itemUid)
     {
         var carriedEntities = _inventorySystem.GetHandOrInventoryEntities(playerUid).ToList();
 


### PR DESCRIPTION
## Summary
- stop grimoire recall from force-displacing held items
- place recalled grimoires in a free hand or compatible carried storage
- preserve items already nested in carried storage
- add integration coverage for realistic casting, nested storage, and failed placement safety

## Validation
- `SummonFoliantTest`: passed
- full `Release` solution restore/build: passed
- merge-tree against `develop`: clean