### PR TITLE
Throwing steel spear damage type change from slash to pierce. Throwing steel spear damage buff.

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -3413,7 +3413,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 21
+        Piercing: 25
   #- type: QualityOfItem
   #  qualityWeights:
   #    0: 0


### PR DESCRIPTION
## О ПР`е 

Тип: Tweak

Изменения:

- Changed the steel spear's throwing damage from Slash damage type to Piercing to be in line with other spears.
- Increased damage from 21 to 25, to be in-line with the damage increase from a better quality material. (Old spear - 15 pierce, Iron spear - 21 pierce, Steel spear - 25 pierce).


## Технические детали

<!-- Сводка изменений кода для более удобного просмотра. -->


*Нет*


## Изменения кода официальных разработчиков

<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->


*Нет* 
