### PR TITLE
Throwing Damage Type Change for Daggers and Short Swords. Throwing Damage Increase for Steel Daggers.

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -1654,7 +1654,7 @@
     resourceCount: 2
 
 - type: entity
-  name: dagger
+  
   parent: [ BaseKnife, BaseDaggerCharged ]
   id: MedievalDaggerT3
   description: A deadly knife intended for melee confrontations.
@@ -1688,7 +1688,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 14
+        Piercing: 14
   #- type: QualityOfItem
   #  qualityWeights:
   #    0: 0
@@ -3333,7 +3333,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 14
+        Piercing: 16
   #- type: QualityOfItem
   #  qualityWeights:
   #    0: 0
@@ -4043,7 +4043,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 14
+        Piercing: 14
         Poison: 3
   #- type: QualityOfItem
   #  qualityWeights:
@@ -4276,7 +4276,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 17
+        Piercing: 17
   #- type: QualityOfItem
   #  qualityWeights:
   #    0: 0
@@ -4359,7 +4359,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 13
+        Piercing: 13
   #- type: QualityOfItem
   #  qualityWeights:
   #    0: 0
@@ -4504,7 +4504,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 19
+        Piercing: 19
   #- type: QualityOfItem
   #  qualityWeights:
   #    0: 0

--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -1654,7 +1654,7 @@
     resourceCount: 2
 
 - type: entity
-  
+  name: dagger
   parent: [ BaseKnife, BaseDaggerCharged ]
   id: MedievalDaggerT3
   description: A deadly knife intended for melee confrontations.


### PR DESCRIPTION
## О ПР`е 

Тип: Tweak

Изменения:

Currently, daggers do slash damage when thrown, even though they are thrown point first and stick into the enemy like a pilum (throwing spear that does piercing when thrown). Also, the steel dagger and iron daggers both do the same throwing damage (14 slash) even though they are different materials. Similarly, short swords are also thrown point first like daggers and do not spin in the air, but do slash damage.

![Alt Text](https://i.imgur.com/wjmR9Hh.gif)

I believe that they should do pierce damage because they are thrown point first, like in the gif above.

Changes:

Throwing damage changed from Slash to Piercing for the following weapons:
- Iron dagger
- Steel dagger
- Bone dagger
- Old short sword
- Iron short sword
- Steel short sword

Throwing damage increased for steel dagger to be in-line with other damage increases from material upgrades.
(Iron dagger 14 -> Steel dagger 16)

## Технические детали

<!-- Сводка изменений кода для более удобного просмотра. -->


*Нет*


## Изменения кода официальных разработчиков

<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->


*Нет* 
