### PR TITLE
Container fix for unique bids/Nocturne conversion fix

### DIFF
--- a/Content.Server/Imperial/Medieval/Nocturn/AncientNocturneSystem.cs
+++ b/Content.Server/Imperial/Medieval/Nocturn/AncientNocturneSystem.cs
@@ -3,14 +3,11 @@ using Content.Server.Destructible;
 using Content.Server.Polymorph.Components;
 using Content.Server.Polymorph.Systems;
 using Content.Shared.Actions;
-using Content.Shared.Alert;
 using Content.Shared.Damage;
 using Content.Shared.DoAfter;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Humanoid;
-using Content.Shared.Imperial.Medieval.Additions;
 using Content.Shared.Imperial.Medieval.Magic;
-using Content.Shared.Inventory;
 using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Nocturn.Components;
@@ -24,14 +21,13 @@ public sealed class AncientNocturneSystem : EntitySystem
 {
     [Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly SharedHandsSystem _hands = default!;
-    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
     [Dependency] private readonly PolymorphSystem _polymorph = default!;
     [Dependency] private readonly SharedActionsSystem _actions = default!;
-    [Dependency] private readonly AlertsSystem _alerts = default!;
     [Dependency] private readonly SharedDoAfterSystem _doAfter = default!;
     [Dependency] private readonly SharedPopupSystem _popup = default!;
     [Dependency] private readonly NocturnBloodSpellSystem _bloodSpells = default!;
+    [Dependency] private readonly NocturneConversionSystem _conversion = default!;
 
     public override void Initialize()
     {
@@ -127,28 +123,16 @@ public sealed class AncientNocturneSystem : EntitySystem
             return;
         }
 
-        var inventory = GetInventorySnapshot(target);
-        var hands = GetHandsSnapshot(target);
-        var activeHand = _hands.GetActiveHand(target);
-
-        if (_polymorph.PolymorphEntity(target, ent.Comp.ConversionPolymorph) is not { } converted)
+        if (!_conversion.TryConvertHumanToNocturne(target, ent.Comp))
             return;
 
-        RestoreInventory(converted, inventory);
-        RestoreHands(converted, hands, activeHand);
-
-        RemComp<PolymorphedEntityComponent>(converted);
-        _alerts.ClearAlert(converted, "SpawnProtection");
-        RemComp<ShieldOnStartupComponent>(converted);
-        QueueDel(target);
-
         var connection = EnsureComp<AncientNocturneMindConnectionComponent>(ent.Owner);
-        var trall = EnsureComp<AncientNocturneTrallMindConnectionComponent>(converted);
-        EnsureComp<AncientNocturneMindChatComponent>(converted);
+        var trall = EnsureComp<AncientNocturneTrallMindConnectionComponent>(target);
+        EnsureComp<AncientNocturneMindChatComponent>(target);
         trall.Master = ent.Owner;
-        connection.Tralls.Add(converted);
+        connection.Tralls.Add(target);
 
-        SendConversionNotification(converted, AncientNocturneConversionNotification.Converted);
+        SendConversionNotification(target, AncientNocturneConversionNotification.Converted);
         if (!connection.HasConvertedTrall)
         {
             connection.HasConvertedTrall = true;
@@ -157,13 +141,13 @@ public sealed class AncientNocturneSystem : EntitySystem
 
         _popup.PopupEntity(
             Loc.GetString("medieval-ancient-nocturne-conversion-success-user"),
-            converted,
+            target,
             ent.Owner,
             PopupType.Medium);
         _popup.PopupEntity(
             Loc.GetString("medieval-ancient-nocturne-conversion-success-target"),
-            converted,
-            converted,
+            target,
+            target,
             PopupType.Large);
     }
 
@@ -211,69 +195,6 @@ public sealed class AncientNocturneSystem : EntitySystem
         {
             _damageable.SetDamage(target, targetDamage, new DamageSpecifier(sourceDamage.Damage));
         }
-    }
-
-    private List<(EntityUid Item, string Slot)> GetInventorySnapshot(EntityUid entity)
-    {
-        var snapshot = new List<(EntityUid Item, string Slot)>();
-        if (!TryComp<InventoryComponent>(entity, out var inventory))
-            return snapshot;
-
-        var enumerator = _inventory.GetSlotEnumerator((entity, inventory));
-        while (enumerator.NextItem(out var item, out var slot))
-        {
-            snapshot.Add((item, slot.Name));
-        }
-
-        return snapshot;
-    }
-
-    private List<(string Hand, EntityUid Item)> GetHandsSnapshot(EntityUid entity)
-    {
-        var snapshot = new List<(string Hand, EntityUid Item)>();
-        foreach (var hand in _hands.EnumerateHands(entity))
-        {
-            if (_hands.TryGetHeldItem(entity, hand, out var item))
-                snapshot.Add((hand, item.Value));
-        }
-
-        return snapshot;
-    }
-
-    private void RestoreInventory(EntityUid entity, List<(EntityUid Item, string Slot)> snapshot)
-    {
-        foreach (var (item, slot) in snapshot)
-        {
-            if (TerminatingOrDeleted(item))
-                continue;
-
-            if (_inventory.TryGetSlotEntity(entity, slot, out var equipped) && equipped == item)
-                continue;
-
-            _inventory.TryEquip(entity, item, slot, true, true, triggerHandContact: true);
-        }
-    }
-
-    private void RestoreHands(
-        EntityUid entity,
-        List<(string Hand, EntityUid Item)> snapshot,
-        string? activeHand)
-    {
-        foreach (var (_, item) in snapshot)
-        {
-            if (_hands.IsHolding(entity, item, out var hand))
-                _hands.DoDrop(entity, hand, doDropInteraction: false, log: false);
-        }
-
-        foreach (var (hand, item) in snapshot)
-        {
-            if (TerminatingOrDeleted(item))
-                continue;
-
-            _hands.DoPickup(entity, hand, item, log: false);
-        }
-
-        _hands.TrySetActiveHand(entity, activeHand);
     }
 
     private bool IsValidConversionTarget(EntityUid target, AncientNocturneComponent component)

--- a/Content.Server/Imperial/Medieval/Nocturn/NocturneConversionSystem.cs
+++ b/Content.Server/Imperial/Medieval/Nocturn/NocturneConversionSystem.cs
@@ -55,6 +55,7 @@ public sealed class NocturneConversionSystem : EntitySystem
         _humanoidAppearance.SetSkinColor(target, nocturneSpecies.DefaultSkinTone, humanoid: appearance);
 
         var nocturne = EnsureComp<NocturnComponent>(target);
+        nocturne.UnmaskedSpecies = configuration.ConversionSpecies;
         if (TryComp<TypingIndicatorComponent>(target, out var typingIndicator))
         {
             typingIndicator.TypingIndicatorPrototype = nocturne.TypingIndicatorPrototypeMod;

--- a/Content.Server/Imperial/Medieval/Nocturn/NocturneConversionSystem.cs
+++ b/Content.Server/Imperial/Medieval/Nocturn/NocturneConversionSystem.cs
@@ -1,0 +1,95 @@
+using Content.Server.BadSmell.Components;
+using Content.Server.Humanoid;
+using Content.Shared.Chat.TypingIndicator;
+using Content.Shared.Humanoid;
+using Content.Shared.Humanoid.Prototypes;
+using Content.Shared.Imperial.Medieval.Magic.Mana;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Components;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.Nocturn.Components;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Nocturn;
+
+public sealed class NocturneConversionSystem : EntitySystem
+{
+    [Dependency] private readonly HumanoidAppearanceSystem _humanoidAppearance = default!;
+    [Dependency] private readonly MobThresholdSystem _mobThreshold = default!;
+    [Dependency] private readonly IPrototypeManager _prototype = default!;
+
+    public bool TryConvertHumanToNocturne(EntityUid target, AncientNocturneComponent configuration)
+    {
+        if (TerminatingOrDeleted(target) ||
+            HasComp<NocturnComponent>(target) ||
+            !TryComp<HumanoidAppearanceComponent>(target, out var appearance) ||
+            appearance.Species != configuration.ConversionTargetSpecies ||
+            !_prototype.TryIndex<SpeciesPrototype>(configuration.ConversionSpecies, out var nocturneSpecies))
+        {
+            return false;
+        }
+
+        RemoveHumanFeatures(target);
+        ConvertToNocturne(target, appearance, nocturneSpecies, configuration);
+        return true;
+    }
+
+    private void RemoveHumanFeatures(EntityUid target)
+    {
+        if (!TryComp<BadSmellRaceModifierComponent>(target, out var humanModifier))
+            return;
+
+        if (humanModifier.Modifier != 0f && TryComp<BadSmellComponent>(target, out var badSmell))
+            badSmell.GrowTemp /= humanModifier.Modifier;
+
+        RemComp<BadSmellRaceModifierComponent>(target);
+    }
+
+    private void ConvertToNocturne(
+        EntityUid target,
+        HumanoidAppearanceComponent appearance,
+        SpeciesPrototype nocturneSpecies,
+        AncientNocturneComponent configuration)
+    {
+        _humanoidAppearance.SetSpecies(target, configuration.ConversionSpecies.Id, false, appearance);
+        _humanoidAppearance.SetSkinColor(target, nocturneSpecies.DefaultSkinTone, humanoid: appearance);
+
+        var nocturne = EnsureComp<NocturnComponent>(target);
+        if (TryComp<TypingIndicatorComponent>(target, out var typingIndicator))
+        {
+            typingIndicator.TypingIndicatorPrototype = nocturne.TypingIndicatorPrototypeMod;
+            Dirty(target, typingIndicator);
+        }
+
+        if (TryComp<ManaComponent>(target, out var mana))
+        {
+            mana.MaxManaRaceModifier = configuration.ConversionMaxManaModifier;
+            mana.RegenRaceModifier = configuration.ConversionManaRegenerationModifier;
+            mana.MaxMana *= configuration.ConversionMaxManaModifier;
+            mana.Mana = Math.Min(mana.Mana, mana.MaxMana);
+            mana.Regen *= configuration.ConversionManaRegenerationModifier;
+            Dirty(target, mana);
+        }
+
+        if (!TryComp<MobThresholdsComponent>(target, out var thresholds))
+            return;
+
+        if (_mobThreshold.TryGetThresholdForState(target, MobState.Dead, out var deadThreshold, thresholds))
+        {
+            _mobThreshold.SetMobStateThreshold(
+                target,
+                deadThreshold.Value * configuration.ConversionMaxHealthModifier,
+                MobState.Dead,
+                thresholds);
+        }
+
+        if (_mobThreshold.TryGetThresholdForState(target, MobState.Critical, out var criticalThreshold, thresholds))
+        {
+            _mobThreshold.SetMobStateThreshold(
+                target,
+                criticalThreshold.Value * configuration.ConversionCriticalThresholdModifier,
+                MobState.Critical,
+                thresholds);
+        }
+    }
+}

--- a/Content.Server/Imperial/Medieval/Nocturn/RaceSystem.cs
+++ b/Content.Server/Imperial/Medieval/Nocturn/RaceSystem.cs
@@ -446,7 +446,7 @@ namespace Content.Server.Nocturn
             if (!component.IsDisguised)
                 return;
 
-            appearance.Species = "Drou";
+            appearance.Species = component.UnmaskedSpecies;
             component.BloodDrainPerSecond /= 1.3f;
 
             component.IsDisguised = false;

--- a/Content.Server/Imperial/Medieval/Trading/TradingSystem.Ui.cs
+++ b/Content.Server/Imperial/Medieval/Trading/TradingSystem.Ui.cs
@@ -744,7 +744,7 @@ public sealed partial class TradingSystem
             return false;
         }
 
-        EmptyItemContainers(sourceItem, seller);
+        EmptyItemStorage(sourceItem, seller);
 
         if (!_containers.Insert(sourceItem, destination, force: true))
         {
@@ -774,16 +774,13 @@ public sealed partial class TradingSystem
         return true;
     }
 
-    private void EmptyItemContainers(EntityUid item, EntityUid seller)
+    private void EmptyItemStorage(EntityUid item, EntityUid seller)
     {
-        if (!TryComp<ContainerManagerComponent>(item, out var containerManager))
+        if (!TryComp<StorageComponent>(item, out var storage))
             return;
 
         var coordinates = Transform(seller).Coordinates;
-        foreach (var container in _containers.GetAllContainers(item, containerManager))
-        {
-            _containers.EmptyContainer(container, true, coordinates);
-        }
+        _containers.EmptyContainer(storage.Container, true, coordinates);
     }
 
     private bool TryFindInventoryItem(

--- a/Content.Shared/Imperial/Medieval/Nocturn/AncientNocturneComponent.cs
+++ b/Content.Shared/Imperial/Medieval/Nocturn/AncientNocturneComponent.cs
@@ -29,11 +29,23 @@ public sealed partial class AncientNocturneComponent : Component
     public TimeSpan BatActionCooldown = TimeSpan.FromMinutes(1);
 
     [DataField]
-    public ProtoId<PolymorphPrototype> ConversionPolymorph = "MedievalAncientNocturneConversionPolymorph";
+    public ProtoId<SpeciesPrototype> ConversionSpecies = "Drou";
 
     [DataField]
     public TimeSpan ConversionDuration = TimeSpan.FromSeconds(6);
 
     [DataField]
     public ProtoId<SpeciesPrototype> ConversionTargetSpecies = "Human";
+
+    [DataField]
+    public float ConversionMaxHealthModifier = 0.95f;
+
+    [DataField]
+    public float ConversionCriticalThresholdModifier = 0.95f;
+
+    [DataField]
+    public float ConversionMaxManaModifier = 0.95f;
+
+    [DataField]
+    public float ConversionManaRegenerationModifier = 0.97f;
 }

--- a/Content.Shared/Imperial/Medieval/Nocturn/NocturnComponent.cs
+++ b/Content.Shared/Imperial/Medieval/Nocturn/NocturnComponent.cs
@@ -4,6 +4,7 @@ using System.Numerics;
 using Content.Shared.Actions;
 using Robust.Shared.Serialization;
 using Content.Shared.DoAfter;
+using Content.Shared.Humanoid.Prototypes;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype;
 using Robust.Shared.Prototypes;
 using Content.Shared.Alert;
@@ -98,6 +99,9 @@ namespace Content.Shared.Nocturn.Components
 
         [DataField]
         public bool IsDisguised = false;
+
+        [DataField]
+        public ProtoId<SpeciesPrototype> UnmaskedSpecies = "Drou";
 
         [DataField, AutoNetworkedField]
         public EntProtoId DisguiseAction = "NocturnDisguiseAction";

--- a/Resources/Locale/en-US/Imperial/Medieval/Nocturn/ancient_nocturne.ftl
+++ b/Resources/Locale/en-US/Imperial/Medieval/Nocturn/ancient_nocturne.ftl
@@ -1,6 +1,7 @@
 ent-MedievalAncientNocturneBloodArrowAction = Blood arrow
     .desc = Shape an arrow from blood and release it from your hand
 ent-BloodArrow = blood arrow
+species-name-ancient-nocturne = Ancient nocturne
 
 ent-MedievalClothingNeckAncientNocturneCloak = Count's cloak
     .desc = After so many years, it remains in perfect condition

--- a/Resources/Locale/ru-RU/Imperial/Medieval/Nocturn/ancient_nocturne.ftl
+++ b/Resources/Locale/ru-RU/Imperial/Medieval/Nocturn/ancient_nocturne.ftl
@@ -1,6 +1,7 @@
 ent-MedievalAncientNocturneBloodArrowAction = Кровавая стрела
     .desc = Сформируйте из крови стрелу и выпустите её из рук
 ent-BloodArrow = кровавая стрела
+species-name-ancient-nocturne = Древний ноктюрн
 
 ent-MedievalClothingNeckAncientNocturneCloak = Графский плащ
     .desc = Спустя столько лет, всё ещё находится в идеальном состоянии

--- a/Resources/Prototypes/Imperial/Medieval/Nocturn/conversion.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Nocturn/conversion.yml
@@ -17,15 +17,3 @@
   - type: EntityTargetAction
     canTargetSelf: false
     event: !type:AncientNocturneConversionActionEvent
-
-- type: polymorph
-  id: MedievalAncientNocturneConversionPolymorph
-  configuration:
-    entity: MobDrou
-    forced: true
-    transferName: true
-    transferDamage: true
-    inventory: Transfer
-    revertOnCrit: false
-    revertOnDeath: false
-    revertOnDelete: false

--- a/Resources/Prototypes/Imperial/Medieval/nocturn.yml
+++ b/Resources/Prototypes/Imperial/Medieval/nocturn.yml
@@ -285,10 +285,10 @@
     thresholds:
       0: Alive
       95: Critical
-      180: Dead
+      190: Dead
   - type: Mana
     maxManaRaceModifier: 0.95
-    regenRaceModifier: 0.95
+    regenRaceModifier: 0.97
   - type: Nocturn
   - type: LocalLight
     energy: 0.4

--- a/Resources/Prototypes/Imperial/Medieval/nocturn.yml
+++ b/Resources/Prototypes/Imperial/Medieval/nocturn.yml
@@ -360,6 +360,8 @@
     - MedievalAncientNocturneEmergencyTeleportAction
     - MedievalAncientNocturneConversionAction
   - type: AncientNocturne
+  - type: Nocturn
+    unmaskedSpecies: AncientDrou
   - type: MedievalSpecialDamageReceiver
     targetType: Werewolf
   - type: BloodRubyOwner
@@ -385,7 +387,7 @@
 
 - type: species
   id: AncientDrou
-  name: Древний ноктюрн
+  name: species-name-ancient-nocturne
   roundStart: false
   prototype: MobAncientDrou
   sprites: MobDrouSprites


### PR DESCRIPTION
Флаконы с едой и жидкостями больше не опустошаются сами при размещении ставки.

Обращённые ноктюрны теперь являются той же сущностью, что и бывшие люди — это исправляет множество связанных ошибок.

Исправления `OnExamine` для древнего ноктюрна.


Food and liquid vials do not empty themself on bid placement

Converted nocturnes are the same entity as former humans, it fixes lots of connected bugs

OnExamine fixes for ancient nocturne