### PR TITLE
Balance MedievalShelterRock.

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Earth/Shelter/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Earth/Shelter/projectiles.yml
@@ -21,7 +21,7 @@
     thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 200
+          damage: 100
         behaviors:
           - !type:DoActsBehavior
             acts: ["Destruction"]

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Earth/Shelter/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Earth/Shelter/projectiles.yml
@@ -14,7 +14,7 @@
   components:
   - type: TimedDespawn
     lifetime: 9
-  - type: DamageAble
+  - type: Damageable
     damageContainer: StructuralInorganic
     damageModifierSet: Rock
   - type: Destructible

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Earth/Shelter/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Earth/Shelter/projectiles.yml
@@ -15,8 +15,8 @@
   - type: TimedDespawn
     lifetime: 9
   - type: DamageAble
-    damageContainer: Inorganic
-    damageModifierSet: Metallic
+    damageContainer: StructuralInorganic
+    damageModifierSet: Rock
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Earth/Shelter/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Earth/Shelter/projectiles.yml
@@ -14,11 +14,14 @@
   components:
   - type: TimedDespawn
     lifetime: 9
+  - type: DamageAble
+    damageContainer: Inorganic
+    damageModifierSet: Metallic
   - type: Destructible
     thresholds:
       - trigger:
           !type:DamageTrigger
-          damage: 1415
+          damage: 200
         behaviors:
           - !type:DoActsBehavior
             acts: ["Destruction"]


### PR DESCRIPTION
Добавил компонент Damageable в MedievalShelterRock (камень в спеллах каменная гряда и укрытие). Изменил значение для уничтожение камней - 100 урона. Без Damageable урон физически некуда записывать, а Destructible никогда не проверяется, независимо от числа в пороге, то есть камень был неразрушимым. 