### PR TITLE
Твики в заклинании ледяных кинжалов | Ice dagger spell tweaks

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/IceDagger/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/IceDagger/projectiles.yml
@@ -109,7 +109,8 @@
     range: 1.15
     damage:
       types:
-        Slash: 12
+        Slash: 11
+        Cold: 1
         ParryAble: 1
     resetOnHandSelected: false
   - type: EmbeddableProjectile

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/IceDagger/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/IceDagger/projectiles.yml
@@ -110,7 +110,7 @@
     damage:
       types:
         Slash: 11
-        Cold: 1
+        Cold: 0.5
         ParryAble: 1
     resetOnHandSelected: false
   - type: EmbeddableProjectile
@@ -120,7 +120,7 @@
     damage:
       types:
         Piercing: 20
-        Cold: 3
+        Cold: 1
   - type: MeleeThrowOnHit
     distance: 0.3
     speed: 5

--- a/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/IceDagger/projectiles.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Magic/Spells/Vodka/IceDagger/projectiles.yml
@@ -34,7 +34,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 12
+        Piercing: 12
   - type: MeleeThrowOnHit
     distance: 0.3
     speed: 5
@@ -76,7 +76,7 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 14
+        Piercing: 14
   - type: MeleeThrowOnHit
     distance: 0.3
     speed: 5
@@ -109,7 +109,7 @@
     range: 1.15
     damage:
       types:
-        Slash: 11
+        Slash: 12
         ParryAble: 1
     resetOnHandSelected: false
   - type: EmbeddableProjectile
@@ -118,7 +118,8 @@
   - type: DamageOtherOnHit
     damage:
       types:
-        Slash: 20
+        Piercing: 20
+        Cold: 3
   - type: MeleeThrowOnHit
     distance: 0.3
     speed: 5


### PR DESCRIPTION
Тип: tweak
Изменения:

Поменял урон ледяным кинжалам при броске на пронзающий ибо всем иным кинжалам поменяли на пронзающий в ином ПРе, слегка апнул архимаг версию, добавив ей лёгкий урон холодом (типо на версии т3 кинжалы уже настолько холодные что наносят ожоги), а также апнул ей урон при ударе на 1 холодом (чуть лучше стального) | Changed ice daggers damage type to pierce when thrown, archmage version buffed a bit by adding minor cold damage to it (kinda like it burns skin with cold on the t3 version), also increased onhit damage of it by 1 cold (now a tiny bit better than the steel dagger).
## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

*Нет*

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*
