### PR TITLE
Force feeding potions

### DIFF
--- a/Content.Shared/Nutrition/Components/EdibleComponent.cs
+++ b/Content.Shared/Nutrition/Components/EdibleComponent.cs
@@ -71,7 +71,7 @@ public sealed partial class EdibleComponent : Component
     ///     Should probably be smaller for small items like pills.
     /// </summary>
     [DataField]
-    public TimeSpan ForceFeedDelay = TimeSpan.FromSeconds(3f);
+    public TimeSpan ForceFeedDelay = TimeSpan.FromSeconds(5f);
 
     /// <summary>
     /// For mobs that are food, requires killing them before eating.

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -296,7 +296,7 @@ public sealed partial class IngestionSystem
     /// Checks if the item is currently edible.
     /// </summary>
     /// <param name="ingested">Entity being ingested</param>
-    /// <param name="user">The entity trying to make the ingestion happening, not necessarily the one eating</param>
+    /// <param name="user">The entity consuming the item.</param>
     /// <param name="solution">Solution we're returning</param>
     /// <param name="time">The time it takes us to eat this entity</param>
     public bool CanAccessSolution(Entity<SolutionContainerManagerComponent?> ingested,

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.API.cs
@@ -134,7 +134,7 @@ public sealed partial class IngestionSystem
             return false;
 
         // If we don't have the tools to eat we can't eat.
-        return CanAccessSolution(ingested, user, out solution, out time);
+        return CanAccessSolution(ingested, user, target, out solution, out time);
     }
 
     #endregion
@@ -304,6 +304,23 @@ public sealed partial class IngestionSystem
         [NotNullWhen(true)] out Entity<SolutionComponent>? solution,
         out TimeSpan? time)
     {
+        return CanAccessSolution(ingested, user, user, out solution, out time);
+    }
+
+    /// <summary>
+    /// Checks if the item is currently edible by a specific target.
+    /// </summary>
+    /// <param name="ingested">Entity being ingested.</param>
+    /// <param name="user">The entity performing the interaction.</param>
+    /// <param name="target">The entity that will consume the solution.</param>
+    /// <param name="solution">The edible solution, if accessible.</param>
+    /// <param name="time">The time required to consume the solution.</param>
+    public bool CanAccessSolution(Entity<SolutionContainerManagerComponent?> ingested,
+        EntityUid user,
+        EntityUid target,
+        [NotNullWhen(true)] out Entity<SolutionComponent>? solution,
+        out TimeSpan? time)
+    {
         solution = null;
         time = null;
 
@@ -313,7 +330,7 @@ public sealed partial class IngestionSystem
             return false;
         }
 
-        var ev = new EdibleEvent(user);
+        var ev = new EdibleEvent(user, target);
         RaiseLocalEvent(ingested, ref ev);
 
         solution = ev.Solution;

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.Blockers.cs
@@ -87,7 +87,9 @@ public sealed partial class IngestionSystem
         }
 
         // Time is additive because I said so.
-        args.Time += entity.Comp.Delay;
+        args.Time += args.User == args.Target
+            ? entity.Comp.Delay
+            : entity.Comp.ForceFeedDelay;
     }
 
     private void OnStorageEdible(Entity<StorageComponent> ent, ref EdibleEvent args)

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -424,6 +424,7 @@ public sealed partial class IngestionSystem : EntitySystem
             BreakOnHandChange = false,
             BreakOnMove = forceFeed,
             BreakOnDamage = true,
+            DuplicateCondition = DuplicateConditions.SameTool | DuplicateConditions.SameEvent,
             MovementThreshold = 0.01f,
             DistanceThreshold = MaxFeedDistance,
             // do-after will stop if item is dropped when trying to feed someone else

--- a/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
+++ b/Content.Shared/Nutrition/EntitySystems/IngestionSystem.cs
@@ -294,10 +294,10 @@ public sealed partial class IngestionSystem : EntitySystem
 
     private void OnEatingDoAfter(Entity<BodyComponent> entity, ref EatingDoAfterEvent args)
     {
-        if (args.Cancelled || args.Handled || entity.Comp.Deleted || args.Target == null)
+        if (args.Cancelled || args.Handled || entity.Comp.Deleted || args.Target == null || args.Used == null)
             return;
 
-        var food = args.Target.Value;
+        var food = args.Used.Value;
 
         var blockerEv = new IngestibleEvent();
         RaiseLocalEvent(food, ref blockerEv);
@@ -412,7 +412,14 @@ public sealed partial class IngestionSystem : EntitySystem
     {
         var forceFeed = user != target;
 
-        var doAfterArgs = new DoAfterArgs(EntityManager, user, delay, new EatingDoAfterEvent(), target, food)
+        var doAfterArgs = new DoAfterArgs(
+            EntityManager,
+            user,
+            delay,
+            new EatingDoAfterEvent(),
+            eventTarget: target,
+            target: target,
+            used: food)
         {
             BreakOnHandChange = false,
             BreakOnMove = forceFeed,

--- a/Content.Shared/Nutrition/IngestionEvents.cs
+++ b/Content.Shared/Nutrition/IngestionEvents.cs
@@ -21,9 +21,14 @@ public record struct IngestibleEvent(bool Cancelled = false);
 /// another entity from consuming the delicious reagents stored inside.
 /// </summary>
 /// <param name="User">The entity trying to feed us to an entity.</param>
+/// <param name="Target">The entity that will consume us.</param>
 [ByRefEvent]
-public record struct EdibleEvent(EntityUid User)
+public record struct EdibleEvent(EntityUid User, EntityUid Target)
 {
+    public EdibleEvent(EntityUid user) : this(user, user)
+    {
+    }
+
     public Entity<SolutionComponent>? Solution = null;
 
     public TimeSpan Time = TimeSpan.Zero;


### PR DESCRIPTION
A current meta-tactic is to grab someone and force feed them a caustic potion. This is an issue because the ingestion system bypasses resistances.

Fixed two bugs with force feeding:
* ForceFeedDelay was never used. So the in game force feed delay was the default feed delay of 1 second. This fixes it to use the actual ForceFeedDelay.
* The ingestion do-after treated the food item as its Target and the victim only as its EventTarget. This meant movement/range checks were performed against the food instead of the person being force-fed.

Balance change:
* ForceFeedDelay changed from 3 secs to 5 secs. Since the grab escape do-after is 3 secs, this change allows the player a chance to escape from getting grabbed before being able to be force fed.
