### PR TITLE
hammer hotfix

### DIFF
--- a/Resources/Prototypes/Imperial/Medieval/ChargedAttack/base.yml
+++ b/Resources/Prototypes/Imperial/Medieval/ChargedAttack/base.yml
@@ -116,17 +116,3 @@
     effectProtoId: AttackEffect2s
   - type: MedievalWeaponSkillCategory
     skill: OneHandedSlashLarge
-
-- type: entity
-  abstract: true
-  id: BaseHammerCharged # This shit needs a separate base
-  components:
-  - type: UseDelayAroundCursor
-  - type: ChargedAttack
-    maxAttackTime: 8.0
-    staticModifier: 3
-    staminaDamage: 50
-    speedModifer: 0.4
-    effectProtoId: AttackEffect4s
-  - type: MedievalWeaponSkillCategory
-    skill: TwoHanded

--- a/Resources/Prototypes/Imperial/Medieval/ChargedAttack/base.yml
+++ b/Resources/Prototypes/Imperial/Medieval/ChargedAttack/base.yml
@@ -116,3 +116,17 @@
     effectProtoId: AttackEffect2s
   - type: MedievalWeaponSkillCategory
     skill: OneHandedSlashLarge
+
+- type: entity
+  abstract: true
+  id: BaseHammerCharged # This shit needs a separate base
+  components:
+  - type: UseDelayAroundCursor
+  - type: ChargedAttack
+    maxAttackTime: 8.0
+    staticModifier: 3
+    staminaDamage: 50
+    speedModifer: 0.4
+    effectProtoId: AttackEffect4s
+  - type: MedievalWeaponSkillCategory
+    skill: TwoHanded

--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -581,7 +581,7 @@
 
 - type: entity
   name: iron hammer
-  parent: [ BaseItem, BaseTwoHandedCharged ]
+  parent: [ BaseItem, BaseHammerCharged ]
   id: MedievalIronHammer
   description: A medieval hammer.
   components:
@@ -622,7 +622,6 @@
     resourceWaste: 0.7
     safeToHitGroup: structure
   - type: Wieldable
-    useDelayOnWield: false
     #wieldTime: 3.5
   - type: IncreaseDamageOnWield
     damage:
@@ -3701,7 +3700,7 @@
 
 - type: entity
   name: iron hammer
-  parent: [ BaseItem, BaseTwoHandedCharged ]
+  parent: [ BaseItem, BaseHammerCharged ]
   id: MedievalIronHammerSteel
   description: A medieval hammer.
   components:
@@ -3742,7 +3741,6 @@
     resourceWaste: 0.7
     safeToHitGroup: structure
   - type: Wieldable
-    useDelayOnWield: false
     #wieldTime: 3.5
   - type: IncreaseDamageOnWield
     damage:

--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -622,11 +622,12 @@
     resourceWaste: 0.7
     safeToHitGroup: structure
   - type: Wieldable
+    useDelayOnWield: false
     #wieldTime: 3.5
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 30
+        Blunt: 17
         Structural: 50
   - type: Item
     size: Huge
@@ -3741,11 +3742,12 @@
     resourceWaste: 0.7
     safeToHitGroup: structure
   - type: Wieldable
+    useDelayOnWield: false
     #wieldTime: 3.5
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 35
+        Blunt: 20
         Structural: 114
   - type: Item
     size: Huge

--- a/Resources/Prototypes/Imperial/Medieval/melee.yml
+++ b/Resources/Prototypes/Imperial/Medieval/melee.yml
@@ -581,7 +581,7 @@
 
 - type: entity
   name: iron hammer
-  parent: [ BaseItem, BaseHammerCharged ]
+  parent: [ BaseItem, BaseTwoHandedCharged ]
   id: MedievalIronHammer
   description: A medieval hammer.
   components:
@@ -626,7 +626,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 61 # this number seems big but it's the exact % difference when comparing attackrate with a halberd
+        Blunt: 30
         Structural: 50
   - type: Item
     size: Huge
@@ -3700,7 +3700,7 @@
 
 - type: entity
   name: iron hammer
-  parent: [ BaseItem, BaseHammerCharged ]
+  parent: [ BaseItem, BaseTwoHandedCharged ]
   id: MedievalIronHammerSteel
   description: A medieval hammer.
   components:
@@ -3745,7 +3745,7 @@
   - type: IncreaseDamageOnWield
     damage:
       types:
-        Blunt: 79 # holy shit. this number seems big but it's the exact % difference when comparing attackrate with a halberd... i hope.
+        Blunt: 35
         Structural: 114
   - type: Item
     size: Huge


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

<!--
    Тип изменения, может быть одним из следующих:
    - feat
    - tweak
    - fix
    - remove

    Ставьте feat, если вы что-то добавили.
    Ставьте tweak, если вы изменили баланс или механику.
    Ставьте fix, если это исправление чего-то.
    Ставьте remove, если вы что-то удалили или ревертнули

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда ставьте feat
-->
Тип: tweak
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения: Молот после ПРа превратился в ручную базуку способную на ваншот за 4 секунды и не имеющую уязвимости в файтах 1 на 1, упс. Пофикшено. Зарядка ПКМа 8 секунд(10 нельзя, на 10 ломается анимация), добавлена обратно задержка удара после взятия в две руки. Еще - 50 стамина урона по кувалдисту от заряженного ПКМа, за урон надо платить.

After the PR, the hammer turned into a handheld bazooka capable of a one shot in 4 seconds, with no vulnerabilities in 1v1 fights, oops. Fixed. RMB charge time is now 8 seconds (10 isn't possible, as the animation breaks), and the attack delay after switching to a two-handed grip has been added back. Also - 50 stamina damage to the user from a charged wideswing, gotta pay for that damage!
<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали
<!-- Сводка изменений кода для более удобного просмотра. -->

*Нет*

## Изменения кода официальных разработчиков
<!-- Сводка изменений кода визардов для более удобного просмотра (Если есть). -->

*Нет*
