### PR TITLE
Centralized Passive Mana.

### DIFF
--- a/Content.Server/Imperial/Medieval/Cult/CultSystem.cs
+++ b/Content.Server/Imperial/Medieval/Cult/CultSystem.cs
@@ -847,7 +847,7 @@ namespace Content.Server.Cult
                     {
                         if (TryComp<ManaComponent>(args.User, out var mana) && mana.MaxManaRaceModifier != 0)
                         {
-                            mana.Regen *= 12.5f;
+                            mana.Regen *= 1.25f;
                             Spawn("ShockWaveEffect", coords);
                             _audioSystem.PlayPvs(comp.SuccesSound, uid);
                             _chat.TrySendInGameICMessage(uid, "Скорость восстановления маны у проводящего ритуал повышена", InGameICChatType.Speak, false);

--- a/Content.Server/Imperial/Medieval/Cult/CultSystem.cs
+++ b/Content.Server/Imperial/Medieval/Cult/CultSystem.cs
@@ -847,7 +847,7 @@ namespace Content.Server.Cult
                     {
                         if (TryComp<ManaComponent>(args.User, out var mana) && mana.MaxManaRaceModifier != 0)
                         {
-                            mana.Regen *= 1.25f;
+                            mana.Regen *= 12.5f;
                             Spawn("ShockWaveEffect", coords);
                             _audioSystem.PlayPvs(comp.SuccesSound, uid);
                             _chat.TrySendInGameICMessage(uid, "Скорость восстановления маны у проводящего ритуал повышена", InGameICChatType.Speak, false);

--- a/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaComponent.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaComponent.cs
@@ -8,7 +8,8 @@ namespace Content.Shared.Imperial.Medieval.Magic.Mana;
 [RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
 public sealed partial class ManaComponent : Component
 {
-    public const float DefaultRegenMultiplier = 10f;
+    public const float DefaultRegenMultiplier = 1f;
+    public const float DefaultRaceCompensator = 1f; // multiplier for races that dont regen every second
 
     [DataField]
     public float RegenRaceModifier = 1f;
@@ -23,19 +24,23 @@ public sealed partial class ManaComponent : Component
     public float MaxMana = 100f;
 
     [DataField, AutoNetworkedField]
-    public float Regen = 0.25f;
+    public float Regen = 2.5f;
 
     [DataField, AutoNetworkedField]
     public float RegenMultiplier = DefaultRegenMultiplier;
-
+    [DataField, AutoNetworkedField]
+    public float RaceTimeCompensator = DefaultRaceCompensator;
+    [DataField, AutoNetworkedField]
+    public float CurrentPassiveManaChange = 0f; // Final passive mana change applied to character on reload
+    [ViewVariables]
+    public Dictionary<EntityUid, float> PassiveManaChanges = new(); //Passive mana sources currently affecting player
 
     [DataField]
     public ProtoId<AlertPrototype> ManaAlert = "Mana";
 
 
     [DataField("reloadTime")]
-    public TimeSpan ReloadTime = TimeSpan.FromSeconds(10f);
-
+    public TimeSpan ReloadTime = TimeSpan.FromSeconds(1f);
 
     [ViewVariables]
     public Dictionary<EntityUid, float> CastedSpells = new();

--- a/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaRegen/ManaRegenComponent.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaRegen/ManaRegenComponent.cs
@@ -15,11 +15,12 @@ public sealed partial class ManaRegenComponent : Component
     [DataField]
     public EntityUid? Equipee;
 
-    [DataField]
+    // This has been replaced with a global timer.
+    /*[DataField]
     public TimeSpan ReloadTime = TimeSpan.FromSeconds(1f);
 
 
     [ViewVariables]
-    public TimeSpan EndTime = TimeSpan.FromSeconds(0f);
+    public TimeSpan EndTime = TimeSpan.FromSeconds(0f);*/
 
 }

--- a/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaRegen/ManaRegenSystem.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaRegen/ManaRegenSystem.cs
@@ -1,4 +1,3 @@
-using Robust.Shared.Timing;
 using Content.Shared.Examine;
 using Content.Shared.Imperial.Medieval.Magic.Mana;
 using Content.Shared.Inventory.Events;
@@ -8,7 +7,6 @@ namespace Content.Shared.Imperial.Medieval.Magic.ManaRegen;
 
 public sealed partial class ManaRegenSystem : EntitySystem
 {
-    [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly ManaSystem _manaSystem = default!;
 
 
@@ -20,46 +18,65 @@ public sealed partial class ManaRegenSystem : EntitySystem
 
         SubscribeLocalEvent<ManaRegenComponent, GotEquippedEvent>(OnEquip);
         SubscribeLocalEvent<ManaRegenComponent, GotUnequippedEvent>(OnUnequip);
+        SubscribeLocalEvent<ManaRegenComponent, ComponentShutdown>(OnShutdown);
     }
-
-    public override void Update(float frameTime)
+    // equiping and unequiping remove and add there mana regen from the total regen pool.
+    private void OnEquip(
+    EntityUid uid,
+    ManaRegenComponent component,
+    GotEquippedEvent args)
     {
-        base.Update(frameTime);
-
-        var enumerator = EntityQueryEnumerator<ManaRegenComponent>();
-
-        while (enumerator.MoveNext(out var _, out var component))
+        if (component.Equipee is { } oldEquipee &&
+        oldEquipee != args.Equipee)
         {
-            if (component.Equipee == null) continue;
-            if (_timing.CurTime <= component.EndTime) continue;
-
-            component.EndTime = _timing.CurTime + component.ReloadTime;
-
-            if (!HasComp<ManaComponent>(component.Equipee.Value)) continue;
-
-            _manaSystem.TryChargeMana(component.Equipee.Value, component.Regen);
+            _manaSystem.RemovePassiveManaChange(oldEquipee, uid);
         }
-    }
 
-    private void OnExamine(EntityUid uid, ManaRegenComponent component, ExaminedEvent args)
-    {
-        var regenMultiplier = TryComp<ManaComponent>(args.Examiner, out var manaComponent)
-            ? manaComponent.RegenMultiplier
-            : ManaComponent.DefaultRegenMultiplier;
-
-        args.PushMarkup(Loc.GetString(
-            component.ManaRegenMessage,
-            ("regen", Math.Round(component.Regen * regenMultiplier, 3))
-        ));
-    }
-
-    private void OnEquip(EntityUid uid, ManaRegenComponent component, GotEquippedEvent args)
-    {
         component.Equipee = args.Equipee;
+
+        _manaSystem.SetPassiveManaChange(args.Equipee, uid, component.Regen);
     }
 
-    private void OnUnequip(EntityUid uid, ManaRegenComponent component, GotUnequippedEvent args)
+    private void OnUnequip(
+    EntityUid uid,
+    ManaRegenComponent component,
+    GotUnequippedEvent args)
     {
+        _manaSystem.RemovePassiveManaChange(
+        args.Equipee,
+        uid);
+
         component.Equipee = null;
+    }
+
+    private void OnShutdown(
+    EntityUid uid,
+    ManaRegenComponent component,
+    ComponentShutdown args)
+    {
+        if (component.Equipee is not { } equipee)
+            return;
+
+        _manaSystem.RemovePassiveManaChange(equipee, uid);
+    }
+    // race mana regen modifier aslo applies to items, not intended but i dont feel like fixing it.
+    private void OnExamine(
+    EntityUid uid,
+    ManaRegenComponent component,
+    ExaminedEvent args)
+    {
+        var regenMultiplier = ManaComponent.DefaultRegenMultiplier;
+        var raceMultiplier = 1f;
+
+        if (TryComp<ManaComponent>(args.Examiner, out var manaComponent))
+        {
+            regenMultiplier = manaComponent.RegenMultiplier;
+            raceMultiplier = manaComponent.RegenRaceModifier;
+        }
+
+        var regen = component.Regen * regenMultiplier * raceMultiplier;
+
+        args.PushMarkup(Loc.GetString(component.ManaRegenMessage, ("regen", Math.Round(regen, 3)
+        )));
     }
 }

--- a/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaSystem.cs
+++ b/Content.Shared/Imperial/Medieval/Magic/Other/Mana/ManaSystem.cs
@@ -44,6 +44,7 @@ public sealed partial class ManaSystem : EntitySystem
             return;
 
         mana.Regen *= component.Modifier;
+        RecalculatePassiveManaChange(uid, mana); // immediately reflect the new modifier.
     }
 
     public override void Update(float frameTime)
@@ -52,12 +53,17 @@ public sealed partial class ManaSystem : EntitySystem
 
         while (enumerator.MoveNext(out var uid, out var component))
         {
-            if (component.MaxMana == 0f) continue;
-            if (_timing.CurTime <= component.EndTime) continue;
+            if (component.MaxMana == 0f)
+                continue;
+            if (_timing.CurTime <= component.EndTime)
+                continue;
 
-            component.EndTime = _timing.CurTime + component.ReloadTime;
+            component.EndTime =
+            _timing.CurTime + component.ReloadTime;
 
-            TryChargeMana(uid, component.Regen, component);
+            RecalculatePassiveManaChange(uid, component);
+
+            TryChangeMana(uid, component.Mana + component.CurrentPassiveManaChange, component);
 
             // if (_net.IsServer)
             //     _alertsSystem.ShowAlert(uid, component.ManaAlert, (short)Math.Clamp(Math.Round(component.Mana / component.MaxMana * 5.05f), 0, 5));
@@ -84,6 +90,7 @@ public sealed partial class ManaSystem : EntitySystem
             component.Regen *= job.RegenJobModifier;
         }
         component.ModifiersApplied = true;
+        RecalculatePassiveManaChange(uid, component); //current passive effect is initialized immediately.
         component.Mana = component.MaxMana;
     }
 
@@ -164,11 +171,56 @@ public sealed partial class ManaSystem : EntitySystem
 
     #region Helpers
 
-    private float GetAllSpellsManaDrain(Dictionary<EntityUid, float> spells) => spells.Aggregate(0.0f, (sum, next) => sum + next.Value);
+    // combine all passive mana effects into a single value.
+    private void RecalculatePassiveManaChange(EntityUid uid, ManaComponent component)
+    {
+        var passiveChanges = component.PassiveManaChanges.Values.Sum();
+
+        component.CurrentPassiveManaChange =
+            (component.Regen + passiveChanges)
+            * component.RegenMultiplier
+            * component.RaceTimeCompensator;
+
+        Dirty(uid, component);
+    }
+
+    private static float GetAllSpellsManaDrain(Dictionary<EntityUid, float> spells) => spells.Aggregate(0.0f, (sum, next) => sum + next.Value);
 
     #endregion
 
     #region Public API
+
+    public bool SetPassiveManaChange(
+    EntityUid uid,
+    EntityUid source,
+    float change,
+    ManaComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return false;
+
+        component.PassiveManaChanges[source] = change;
+
+        RecalculatePassiveManaChange(uid, component);
+
+        return true;
+    }
+
+    public bool RemovePassiveManaChange(
+    EntityUid uid,
+    EntityUid source,
+    ManaComponent? component = null)
+    {
+        if (!Resolve(uid, ref component))
+            return false;
+
+        if (!component.PassiveManaChanges.Remove(source))
+            return false;
+
+        RecalculatePassiveManaChange(uid, component);
+
+        return true;
+    }
 
     public bool TryChangeMana(EntityUid uid, float mana, ManaComponent? component = null)
     {


### PR DESCRIPTION
## About the PR

Type: Tweak

Changes: Reworked passive mana regeneration and drain to combine all passive effects into one character-based mana tick.

## Technical Details

* Passive mana effects are now summed into `CurrentPassiveManaChange`.
* `ReloadTime` controls the character's mana tick interval. useful for making other races more unique.
   example: elf regenerates 2 mana every second but the rat kin regenerates 5 mana every 5 seconds.
   right now, it is set to default 1sec unless it is overridden in .yml
* Added `RaceTimeCompensator` for slower race regen intervals. This is a multiplier in case a race regens time is longer then 1 second, it's a bit redundant but I added it because multiplying is useful.
 for example, base regen is 2, but this character only regenerates every 10 seconds, so you set its multiplier to 10 so it receives 20 mana on its regeneration Tic. 

* Default `RegenMultiplier` changed from `10` to `1`. I believe this is what it is set to in the live build right now. 

* Add passive effects with:

```csharp
_manaSystem.SetPassiveManaChange(target, source, value);
```

* Remove them with:

```csharp
_manaSystem.RemovePassiveManaChange(target, source);
```
this could be used to make the light spell drain mana passively while instead of having an upfront mana cost.  

## Official Developer Code Changes

*None*

---

## О ПР

Тип: Tweak

Изменения: Переработана пассивная регенерация и потеря маны: теперь все пассивные эффекты объединяются в один тик маны, привязанный к персонажу.

## Технические детали

* Пассивные эффекты маны теперь суммируются в `CurrentPassiveManaChange`.

* `ReloadTime` управляет интервалом тика маны персонажа. Это полезно для того, чтобы сделать разные расы более уникальными.
  Пример: эльф восстанавливает 2 маны каждую секунду, а крысолюд восстанавливает 5 маны каждые 5 секунд.
  Сейчас значение по умолчанию установлено на 1 секунду, если оно не переопределено в `.yml`.

* Добавлен `RaceTimeCompensator` для рас с более долгим интервалом регенерации. Это множитель на случай, если время регенерации расы больше 1 секунды. Это немного избыточно, но я добавил его, потому что возможность использовать множитель может быть полезна.
  Например, базовая регенерация равна 2, но персонаж восстанавливает ману только раз в 10 секунд. В таком случае можно установить множитель на 10, чтобы персонаж получал 20 маны за один тик регенерации.

* Значение `RegenMultiplier` по умолчанию изменено с `10` на `1`. Насколько я понимаю, именно такое значение сейчас используется в live-сборке.

* Добавить пассивный эффект можно с помощью:

```csharp
_manaSystem.SetPassiveManaChange(target, source, value);
```

* Удалить пассивный эффект можно с помощью:

```csharp
_manaSystem.RemovePassiveManaChange(target, source);
```

Это можно использовать, например, чтобы заклинание света пассивно расходовало ману во время действия вместо того, чтобы иметь единоразовую стоимость маны при использовании.

## Официальные изменения кода разработчика

*None*

