### PR TITLE
Balance Myrmex.

### DIFF
--- a/Content.Server/Imperial/Medieval/BloodRegenBed/BloodRegenBedComponent.cs
+++ b/Content.Server/Imperial/Medieval/BloodRegenBed/BloodRegenBedComponent.cs
@@ -5,5 +5,9 @@ namespace Content.Server.Imperial.Medieval.BloodRegenBed
     {
         [DataField("bloodRegenMultiplier", required: true)]
         public float BloodRegenMultiplier = 10.0f; // Добавляем 10 единиц крови каждые 5 секунд
+        
+        // imperial medieval - how much bleeding severity is staunched per tick. 0 = no change to vanilla behaviour
+        [DataField("bleedReduction")]
+        public float BleedReduction = 0f;
     }
 }

--- a/Content.Server/Imperial/Medieval/BloodRegenBed/BloodRegenBedSystem.cs
+++ b/Content.Server/Imperial/Medieval/BloodRegenBed/BloodRegenBedSystem.cs
@@ -76,6 +76,8 @@ namespace Content.Server.Imperial.Medieval.BloodRegenBed
                     {
                         continue;
                     }
+                    if (bloodRegen.BleedReduction > 0f)
+                        _bloodstreamSystem.TryModifyBleedAmount(buckledEntity, -bloodRegen.BleedReduction);
 
                     if (_bloodstreamSystem.GetBloodLevelPercentage(buckledEntity) >= 1.0f)
                     {

--- a/Content.Server/Imperial/Medieval/Myrmex/Components/MyrmexComponent.cs
+++ b/Content.Server/Imperial/Medieval/Myrmex/Components/MyrmexComponent.cs
@@ -10,7 +10,7 @@ namespace Content.Server.Myrmex.Components;
 public sealed partial class MyrmexComponent : Component
 {
     [DataField]
-    public List<EntProtoId> Actions;
+    public List<EntProtoId> Actions = new();
 
     [DataField]
     public float CurrentSpeedMultiplier = 1;

--- a/Content.Server/Imperial/Medieval/Myrmex/MyrmexSystem.cs
+++ b/Content.Server/Imperial/Medieval/Myrmex/MyrmexSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Body.Components;
 using Content.Shared.Damage;
 using Content.Shared.Examine;
 using Content.Shared.Imperial.Zlevels;
+using Content.Shared.Imperial.Medieval.Myrmex; // imperial medieval - MyrmexHungerComponent
 using Content.Shared.Inventory;
 using Content.Shared.Jittering;
 using Content.Shared.Maps;
@@ -55,11 +56,23 @@ namespace Content.Server.Myrmex
         public override void Initialize()
         {
             SubscribeLocalEvent<MyrmexComponent, ComponentStartup>(OnMyrmexStartup);
+            SubscribeLocalEvent<MyrmexHungerComponent, BeforeDamageChangedEvent>(OnFriendlyFirePrevention); //imperial medieval - backstop for indirect damage (acid,turret)
             SubscribeLocalEvent<MyrmexEggComponent, ExaminedEvent>(OnEggExamined);
             SubscribeLocalEvent<MyrmexEggComponent, ComponentStartup>(OnEggStartup);
             SubscribeLocalEvent<MyrmexHoleComponent, ComponentStartup>(OnHoleStartup);
 
             InitializeActions();
+        }
+
+        // imperial medieval - backstop for indirect myrmex damage (spitter acid, turret)
+        private void OnFriendlyFirePrevention(EntityUid uid, MyrmexHungerComponent comp, ref BeforeDamageChangedEvent args)
+        {
+            if (args.Origin is not { } origin)
+                return;
+
+            if (!HasComp<MyrmexHungerComponent>(origin))
+                return;
+            args.Cancelled = true; 
         }
 
         private void OnMyrmexStartup(Entity<MyrmexComponent> myrmex, ref ComponentStartup args)

--- a/Content.Server/LandMines/LandMineSystem.cs
+++ b/Content.Server/LandMines/LandMineSystem.cs
@@ -5,8 +5,8 @@ using Content.Shared.Popups;
 using Content.Shared.StepTrigger.Systems;
 using Content.Shared.Trigger.Systems;
 using Robust.Shared.Audio.Systems;
-using Content.Server.Myrmex.Components; // imperial medieval
-
+using Content.Server.Myrmex.Components;// imperial medieval
+using Content.Shared.Imperial.Medieval.Myrmex; // imperial medieval - larvacomponent
 namespace Content.Server.LandMines;
 
 public sealed class LandMineSystem : EntitySystem
@@ -29,7 +29,7 @@ public sealed class LandMineSystem : EntitySystem
     /// </summary>
     private void HandleStepOnTriggered(EntityUid uid, LandMineComponent component, ref StepTriggeredOnEvent args)
     {
-        if (HasComp<MyrmexComponent>(args.Tripper)) return; // imperial medieval
+        if (HasComp<MyrmexComponent>(args.Tripper) || HasComp<LarvaComponent>(args.Tripper)) return; // imperial medieval
         if (!string.IsNullOrEmpty(component.TriggerText))
           {
               _popupSystem.PopupCoordinates(
@@ -46,6 +46,7 @@ public sealed class LandMineSystem : EntitySystem
     /// </summary>
     private void HandleStepOffTriggered(EntityUid uid, LandMineComponent component, ref StepTriggeredOffEvent args)
     {
+        if (HasComp<MyrmexComponent>(args.Tripper) || HasComp<LarvaComponent>(args.Tripper)) return; // imperial medieval - safety net
         // TODO: Adjust to the new trigger system
         _trigger.Trigger(uid, args.Tripper, TriggerSystem.DefaultTriggerKey);
     }
@@ -56,10 +57,16 @@ public sealed class LandMineSystem : EntitySystem
     /// </summary>
     private void HandleStepTriggerAttempt(EntityUid uid, LandMineComponent component, ref StepTriggerAttemptEvent args)
     {
-        if (HasComp<MyrmexComponent>(args.Tripper)) return; // imperial medieval
+        // imperial medieval - myrmex and their larvae never set off their own traps
+        if (HasComp<MyrmexComponent>(args.Tripper) || HasComp<LarvaComponent>(args.Tripper))
+        {
+           args.Cancelled = true;
+           return;
+        }
+
         args.Continue = true;
 
         if (HasComp<ArmableComponent>(uid) && TryComp<ItemToggleComponent>(uid, out var itemToggle))
-            args.Continue = itemToggle.Activated;
+           args.Continue = itemToggle.Activated;
     }
 }

--- a/Content.Shared/Imperial/Medieval/Myrmex/SharedMyrmexHungerSystem.cs
+++ b/Content.Shared/Imperial/Medieval/Myrmex/SharedMyrmexHungerSystem.cs
@@ -1,9 +1,12 @@
-﻿using Content.Shared.Alert;
+using Content.Shared.Actions.Events;
+using Content.Shared.Alert;
 using Content.Shared.Damage;
 using Content.Shared.Damage.Events;
 using Content.Shared.Examine;
 using Content.Shared.Imperial.Dash;
 using Content.Shared.Imperial.Medieval.Sprint;
+using Content.Shared.Interaction.Events;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee.Events;
@@ -34,6 +37,25 @@ namespace Content.Shared.Imperial.Medieval.Myrmex
             SubscribeLocalEvent<MyrmexHungerComponent, GunShotEvent>(OnGunShot);
             SubscribeLocalEvent<MyrmexHungerComponent, DamageModifyEvent>(OnGetDamageModifiers);
             SubscribeLocalEvent<MyrmexHungerComponent, ExaminedEvent>(OnExamined);
+
+            // imperial medieval - myrmex - myrmex never attach each other, client-predicted
+            SubscribeLocalEvent<MyrmexHungerComponent, AttackAttemptEvent>(OnMyrmexAttackAttempt);
+            SubscribeLocalEvent<MyrmexHungerComponent, DisarmAttemptEvent>(OnMyrmexDisarmAttempt);
+        }
+
+        private bool IsMyrmex(EntityUid uid) => HasComp<MyrmexHungerComponent>(uid);
+
+        private void OnMyrmexAttackAttempt(EntityUid uid, MyrmexHungerComponent comp, AttackAttemptEvent args)
+        {
+            if (args.Target is { } target && IsMyrmex(target))
+                args.Cancel();
+        }
+        
+        
+        private void OnMyrmexDisarmAttempt(EntityUid uid, MyrmexHungerComponent comp, ref DisarmAttemptEvent args)
+        {
+            if (IsMyrmex(args.DisarmerUid) && IsMyrmex(args.TargetUid))
+               args.Cancelled = true;
         }
 
         private void OnInit(EntityUid uid, MyrmexHungerComponent comp, ref ComponentInit args)
@@ -64,6 +86,10 @@ namespace Content.Shared.Imperial.Medieval.Myrmex
 
         private void OnExamined(EntityUid uid, MyrmexHungerComponent comp, ref ExaminedEvent args)
         {
+            // imperial medieval - only living myrmex show buff stats, not myrmex-owned structures like the turret
+            if (!HasComp<MobStateComponent>(uid))
+                return;
+                
             var buff = MyrmexBuff.MultiplyBuffs(comp.Buffs);
             args.PushMarkup(Loc.GetString("medieval-myrmex-buff-health-examine", ("value", Math.Round(buff.Health, 2))));
             args.PushMarkup(Loc.GetString("medieval-myrmex-buff-damage-examine", ("value", Math.Round(buff.Damage, 2))));

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/actions.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/actions.yml
@@ -60,7 +60,7 @@
     icon: Imperial/Medieval/Myrmex/Icons/wall.png
     priority: -12
     checkCanAccess: false
-    useDelay: 18
+    useDelay: 8
   - type: InstantAction
     event: !type:ActionMyrmexSpawnEvent
       proto: MedievalMyrmexFlimsyWall

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmex.yml
@@ -123,7 +123,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 500
+        damage: 400
       behaviors:
       - !type:DoActsBehavior
         acts: ["Destruction"]
@@ -160,7 +160,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 400
+        damage: 250
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -194,7 +194,7 @@
     thresholds:
     - trigger:
         !type:DamageTrigger
-        damage: 1600
+        damage: 900
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Destruction" ]
@@ -502,7 +502,7 @@
   - type: IgnoreSpiderWeb
   - type: Bloodstream
     bloodReagent: CopperBlood
-    bloodMaxVolume: 100
+    bloodMaxVolume: 200
   - type: Puller
   - type: Appearance
   - type: Speech
@@ -623,7 +623,7 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 8
+        Brute: 11
       types:
         ParryAble: 1
         Structural: 85
@@ -632,6 +632,12 @@
       0: Alive
       65: Critical
       140: Dead
+  - type: Stamina
+    critThreshold: 120 
+    stunTime: 5
+    cooldown: 2.5
+    decay: 3.5
+    afterCritDecayMultiplier: 5
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.2
     baseSprintSpeed: 2
@@ -690,9 +696,10 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 7
+        Brute: 12
       types:
         ParryAble: 1
+        Structural: 10
   - type: Gun
     fireRate: 0.75
     useKey: false
@@ -705,6 +712,12 @@
       0: Alive
       100: Critical
       170: Dead
+  - type: Stamina
+    critThreshold: 115
+    stunTime: 5
+    cooldown: 2.5
+    decay: 3.5
+    afterCritDecayMultiplier: 5
   - type: MovementSpeedModifier
     baseWalkSpeed: 3.4
     baseSprintSpeed: 2.2
@@ -744,9 +757,9 @@
   - type: Projectile
     damage:
       types:
-        Caustic: 2.0
-        Blunt: 3.0
-
+        Caustic: 7.0
+        Blunt: 6.0
+        Structural: 10
 - type: entity
   name: myrmalisk
   parent: MedievalMyrmexBase
@@ -770,14 +783,21 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 22
+        Brute: 26
       types:
         ParryAble: 1
+        Structural: 10
   - type: MobThresholds
     thresholds:
       0: Alive
       310: Critical # curse of 220. no. 310.
       450: Dead
+  - type: Stamina
+    critThreshold: 160
+    stunTime: 4
+    cooldown: 2.5
+    decay: 4
+    afterCritDecayMultiplier: 5
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 1.8
@@ -832,14 +852,21 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 14
+        Brute: 18
       types:
         ParryAble: 1
+        Structural: 10
   - type: MobThresholds
     thresholds:
       0: Alive
       155: Critical
       270: Dead
+  - type: Stamina
+    critThreshold: 140
+    stunTime: 5
+    cooldown: 2.5
+    decay: 4
+    afterCritDecayMultiplier: 5
   - type: MovementSpeedModifier
     baseWalkSpeed: 4.2
     baseSprintSpeed: 2.7
@@ -878,6 +905,10 @@
   id: MedievalMyrmexLarva
   components:
   - type: Larva
+  - type: Myrmex #imperial medieval - larvae count as myrmex for traps, friendly fire and other checks
+    actions: []
+  - type: MyrmexHunger
+    eatCooldownSeconds: 80
   - type: Butcherable
     spawned:
     - id: FoodMeat
@@ -982,8 +1013,8 @@
       collection: MyrmexAttack
     damage:
       groups:
-        Brute: 28
-        Airloss: 1
+        Brute: 30
+        Airloss: 2
       types:
         ParryAble: 1
         Bloodloss: 2
@@ -993,6 +1024,12 @@
       0: Alive
       750: Critical
       900: Dead
+  - type: Stamina
+    critThreshold: 200
+    stunTime: 3
+    cooldown: 2.5
+    decay: 4
+    afterCritDecayMultiplier: 5
   - type: MovementSpeedModifier
     baseWalkSpeed: 3
     baseSprintSpeed: 2.2

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexbuilding.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexbuilding.yml
@@ -1127,18 +1127,6 @@
           sprite: Imperial/Medieval/Myrmex/resin.rsi
           state: clearresin
         doAfter: 1
-      - tag: MyrmexResourceYant
-        name: янтарь # Imperial Recipes Locale
-        icon:
-          sprite: Imperial/Medieval/Myrmex/resin.rsi
-          state: clearresin
-        doAfter: 1
-      - tag: MyrmexResourceYant
-        name: янтарь # Imperial Recipes Locale
-        icon:
-          sprite: Imperial/Medieval/Myrmex/resin.rsi
-          state: clearresin
-        doAfter: 1
       - tag: MedievalAntHitin
         name: хитин # Imperial Recipes Locale
         icon:

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexsoup.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexsoup.yml
@@ -56,7 +56,7 @@
   components:
   - type: MyrmexStew
     buff:
-      damage: 1.05
+      damage: 1.02
       health: 1.02
       stamina: 0.98
   - type: Sprite

--- a/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexturret.yml
+++ b/Resources/Prototypes/Imperial/Medieval/Myrmex/myrmexturret.yml
@@ -4,6 +4,7 @@
   name: myrmex turret
   description: Shoots 9mm acid projectiles.
   components:
+  - type: MyrmexHunger # imperial medieval - marks the turret as "myrmex-owned" so its bullets don't hurt the hive
   - type: NpcFactionMember
     factions:
     - Dragon

--- a/Resources/Prototypes/Imperial/Medieval/myrmestructures.yml
+++ b/Resources/Prototypes/Imperial/Medieval/myrmestructures.yml
@@ -385,22 +385,27 @@
   - type: Strap
     buckleTime: 0.5
     unbuckleTime: 0.5
+    whitelist:
+      tags:
+      - MyrmexPoisonImmune
   - type: Buckle
   - type: BloodRegenBed
-    bloodRegenMultiplier: 2.0
+    bloodRegenMultiplier: 6.0
+    bleedReduction: 4.0
   - type: Sprite
     sprite: Imperial/Medieval/Myrmex/Structures/myrmex_bed.rsi
     state: icon
   - type: HealOnBuckle
     damage:
       groups:
-        Brute: -0.3
-        Burn: -0.3
-        Airloss: -1.1
+        Brute: -0.5
+        Burn: -0.5
+        Airloss: -1.8
       types:
-        Poison: -0.12
-        Caustic: -0.1
+        Poison: -0.2
+        Caustic: -0.18
         Radiation: -0.12
+        Bloodloss: -1.5
   - type: Construction
     graph: MMyrmexBed
     node: medievalMyrmexBed


### PR DESCRIPTION
## О ПР`е


Тип: tweak
Изменения: 
- Немного поднят урон всех мирмексов, взамен снижено добавление урона с живичного рагу 1.05 -> 1.02.
- Добавлен структурный урон(10): мирмакриду, мирмалиску, мирмедонту для лучшей помощи улью в добыче ресурсов.
- КД на постройку стен у мирмелинга уменьшена с 18 -> 8 секунд. Взамен снижена прочности всех стен и дверей: хлипкая 400 -> 250, крепкая 1600 -> 900, дверь 500 -> 400.
- Увеличен объем крови мирмексов 100 -> 200, из-за того, что мирмексы быстро набирают кровопотерю и теряют кровь. 
- Снижена стоимость крафта инкубатора сгустков было 7 -> 5 янтаря.
- Переработана стамина по кастам вместо единого(100) порога для всех. 
- Усилено лечение на лежанке мирмексов и добавлена остановка кровотечения, теперь никто кроме мирмексов не сможет лечь на лежанку. 
- Ускорен голод личинки с 120 -> 80 секунд, чтобы рост в касту занимал не так долго.
- Убран FF для мирмексов, теперь мирмексы не смогут ранить друг друга.
- Исправлен баг, при котором личинка подрывала ловушки мирмексов. 

Changes:
Slightly buffed damage across all myrmex castes, in exchange lowered the resin stew buff 1.05 -> 1.02. Added structural damage(10) to myrmacrid, myrmalisk, and myrmedont so they can actually pull their weight mining resources for the hive. Cut the myrmeling's wall-build cooldown from 18 -> 8 seconds; in exchange lowered the HP of all walls and doors: flimsy 400 -> 250, strong 1600 -> 900, door 500 -> 400. Bumped myrmex blood volume 100 -> 200, since they were bleeding out and losing blood way too fast. Lowered the clot incubator craft cost from 7 -> 5 amber. Reworked stamina thresholds per caste instead of a flat 100 for everyone. Buffed healing on the myrmex resin bed and added bleed staunching, and now only myrmex can actually use the bed. Sped up larva hunger from 120 -> 80 seconds so growing into a caste doesn't take forever. Removed FF between myrmex, so they can no longer hurt each other. Fixed a bug where larvae would set off myrmex traps.
## Технические детали
Надеюсь, с этим списком изменений мирмексам станет чуть комфортнее играть, раньше вечная нехватка стамины, постоянный мыльный экран из-за того, что кровь восстанавливалась долго, и то, что даже лежа на лежанке ты всё равно кровоточил, ощутимо мешали получать удовольствие от игры. Также был негативный опыт у меня и у других, что злостные нарушители убивали своих же. 
Также в будущем надо добавить, чтобы можно было смотреть за всеми, кто у тебя в улье за любого мирмекса, дабы знать кто и где, а также не помешало бы "трекер" на квину для того, чтобы знать где сейчас находится королева. Не помешало бы добавить, чтобы весь улей знал, когда королева погибла. А также возможность, что после смерти королевы улей не "умирал", а вместо неё мог любой мирмекс эволюционировать в неё.

## Technical details
Hoping this makes playing myrmex a bit less miserable overall the constant stamina starvation, the never-ending vision-blur from blood taking forever to regen, and bleeding out even while lying in the bed were all genuinely killing the fun. Also had some bad experiences (mine and other people's) with griefers killing their own hivemates before this fix.

Some ideas for later (not part of this PR):
- Ability to spectate any myrmex in your hive to keep track of who's where
- A "tracker" for the queen so the hive knows her location at all times
- Hive-wide notification when the queen dies
- Instead of the hive dying with the queen, any myrmex could evolve into a new one