### PR TITLE
Chat spam folding

### DIFF
--- a/Content.Client/Imperial/Medieval/Chat/RepeatedChatMessage.cs
+++ b/Content.Client/Imperial/Medieval/Chat/RepeatedChatMessage.cs
@@ -1,0 +1,38 @@
+using Content.Shared.Chat;
+using Robust.Shared.Utility;
+
+namespace Content.Client.Imperial.Medieval.Chat;
+
+/// <summary>
+///     imperial medieval - a chat line folded with its repeats, showing "xN" instead of
+///     printing the same text again. Client-side only.
+/// </summary>
+public sealed class RepeatedChatMessage
+{
+    /// <summary>
+    ///     Index of this line in the chat OutputPanel. Invalid once the panel is cleared.
+    /// </summary>
+    public readonly int Index;
+
+    /// <summary>
+    ///     The formatted line without any "xN" suffix.
+    /// </summary>
+    public readonly FormattedMessage Original;
+
+    /// <summary>
+    ///     Raw unwrapped text, used for comparing messages.
+    /// </summary>
+    public readonly string Text;
+
+    public readonly ChatChannel Channel;
+
+    public int Count = 1;
+
+    public RepeatedChatMessage(int index, FormattedMessage original, string text, ChatChannel channel)
+    {
+        Index = index;
+        Original = original;
+        Text = text;
+        Channel = channel;
+    }
+}

--- a/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Widgets/ChatBox.xaml.cs
@@ -1,3 +1,4 @@
+using Content.Client.Imperial.Medieval.Chat; // imperial medieval - repeated chat messages
 using Content.Client.UserInterface.Systems.Chat.Controls;
 using Content.Shared.Chat;
 using Content.Shared.Input;
@@ -24,7 +25,11 @@ public partial class ChatBox : UIWidget
 
     private readonly ISawmill _sawmill;
     private readonly ChatUIController _controller;
-
+    
+    // imperial medieval - recent lines eligible for "xN" folding. Bounded, so it never grows with the round.
+    private const int RepeatHistory = 10;
+    private readonly Queue<RepeatedChatMessage> _repeatQueue = new();
+    
     public bool Main { get; set; }
 
     public ChatSelectChannel SelectedChannel => ChatInput.ChannelSelector.SelectedChannel;
@@ -52,7 +57,6 @@ public partial class ChatBox : UIWidget
     {
         _controller.SendMessage(this, SelectedChannel);
     }
-
     private void OnMessageAdded(ChatMessage msg)
     {
         _sawmill.Debug($"{msg.Channel}: {msg.Message}");
@@ -68,7 +72,62 @@ public partial class ChatBox : UIWidget
 
         var color = msg.MessageColorOverride ?? msg.Channel.TextColor();
 
-        AddLine(msg.WrappedMessage, color);
+        // imperial medieval - fold repeats instead of printing the same line again.
+        // Checked before building the line so folded messages cost no markup parsing.
+        if (TryFoldRepeat(msg))
+            return;
+
+        var formatted = BuildLine(msg.WrappedMessage ?? string.Empty, color);
+
+        _repeatQueue.Enqueue(new RepeatedChatMessage(Contents.EntryCount, formatted, msg.Message, msg.Channel));
+
+        while (_repeatQueue.Count > RepeatHistory)
+        {
+            _repeatQueue.Dequeue();
+        }
+
+        Contents.AddMessage(formatted);
+    }
+
+    /// <summary>
+    ///     imperial medieval - folds this message into a matching recent one instead of printing it again.
+    ///     Matches the oldest entry in the queue.
+    /// </summary>
+    private bool TryFoldRepeat(ChatMessage msg)
+    {
+        foreach (var old in _repeatQueue)
+        {
+            // msg.Message can be null; string.Equals handles that without throwing
+            if (old.Channel != msg.Channel || !string.Equals(old.Text, msg.Message, StringComparison.Ordinal))
+                continue;
+
+            // Bounds guard only. Correctness relies on the queue being cleared whenever the panel is,
+            // which is done in Repopulate and OnChannelFilter - this just keeps a missed clear from
+            // throwing instead of silently writing to whatever line now sits at that index.
+            if (old.Index >= Contents.EntryCount)
+                return false;
+
+            old.Count++;
+
+            var copy = new FormattedMessage(old.Original);
+            copy.AddMarkupPermissive($" [color=red]x{old.Count}[/color]");
+            Contents.SetMessage(old.Index, copy);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    ///     imperial medieval - builds a chat line without printing it, so it can be stored for repeat folding.
+    /// </summary>
+    private FormattedMessage BuildLine(string message, Color color)
+    {
+        var formatted = new FormattedMessage(3);
+        formatted.PushColor(color);
+        formatted.AddMarkupOrThrow(message);
+        formatted.Pop();
+        return formatted;
     }
 
     private void OnHighlightsUpdated(string highlights)
@@ -84,16 +143,18 @@ public partial class ChatBox : UIWidget
     public void Repopulate()
     {
         Contents.Clear();
+        _repeatQueue.Clear(); // imperial medieval - indices are invalid after a clear
 
         foreach (var message in _controller.History)
         {
             OnMessageAdded(message.Item2);
         }
     }
-
+    
     private void OnChannelFilter(ChatChannel channel, bool active)
     {
         Contents.Clear();
+        _repeatQueue.Clear(); // imperial medieval - indices are invalid after a clear
 
         foreach (var message in _controller.History)
         {
@@ -113,11 +174,7 @@ public partial class ChatBox : UIWidget
 
     public void AddLine(string message, Color color)
     {
-        var formatted = new FormattedMessage(3);
-        formatted.PushColor(color);
-        formatted.AddMarkupOrThrow(message);
-        formatted.Pop();
-        Contents.AddMessage(formatted);
+        Contents.AddMessage(BuildLine(message, color));
     }
 
     public void Focus(ChatSelectChannel? channel = null)


### PR DESCRIPTION
## О ПР`е
<!-- Эта информация попадет в чейнджлог, пожалуйста, заполните ее -->

Тип/Type: feat
<!--
    Что вы изменили?
    Пишите от третьего лица, кратко.
    Не переносите текст на следующую строку.
    Пример: "Урон от туллбокса был увеличен в два раза"

    Если вы добавляете/изменяете/удаляете ивентовый контент, то всегда пишите "Ивентовый контент"
-->
Изменения/Changes: 
RU
Спам одинаковыми сообщениями в чате больше не повторяется в кучу строк, теперь просто добавляется х2, х3 и тд к первому сообщению. Работает в любом канале, не важно кто пишет, хоть один человек спамит, хоть несколько все равно считается. Наиболее актуально, после рестарта раунда в OOC чате, когда там происходит просто сущий ад...

ENG
Spammed duplicate chat messages no longer flood the chat with a wall of identical lines  instead the first message gets a x2, x3, etc counter tacked on. Works in any channel, doesn't matter if it's one person spamming or a bunch of different people saying the same thing, it all counts toward the same counter. Comes in handy most right after a round restart, when OOC usually turns into everyone typing the same thing at once.

https://github.com/user-attachments/assets/f6b3b141-69f0-452a-a9e6-c1ee305854da


<!--
    Пример правильного заполнения:

    Тип: tweak
    Изменения: Урон от туллбокса был увеличен в два раза
-->

## Технические детали/ Technical details
<!-- Сводка изменений кода для более удобного просмотра. -->
RU
За основу взята идея, реализованная в RMC-14. Логика переписана под наш чат: очередь повторов чистится при любой перерисовке панели чата(смена фильтра каналов, обновление истории), чтобы индексы строк не протухали.

ENG
Idea's based on what RMC-14 does. Rewrote the logic for our chat: the repeat queue gets cleared on any chatbox repaint (channel filter toggle, history refresh) so line indices never go stale.

